### PR TITLE
Issue/15/fake data

### DIFF
--- a/clmm/__init__.py
+++ b/clmm/__init__.py
@@ -4,3 +4,4 @@ from __future__ import absolute_import
 from .models import *
 from .summarizer import *
 from .core import *
+from .mock_data import *

--- a/clmm/mock_data.py
+++ b/clmm/mock_data.py
@@ -56,7 +56,8 @@ class MockData(CLMMBase):
             self.config['cosmo'] = 'WMAP7-ML'
             self.config['mdef'] = '200c'
             self.config['concentration'] = 4
-            
+
+        self.ask_type = ['raw_data']
 
     def generate(self, is_shapenoise=False, shapenoise=0.005, is_zerr=False, sigma_z=0.05):
         '''

--- a/clmm/mock_data.py
+++ b/clmm/mock_data.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 from astropy.table import Table
 
 
-class MockData(): 
+class MockData(CLMMBase): 
     '''
     A class that generates a mock background galaxy catalog around a galaxy cluster
     
@@ -61,16 +61,16 @@ class MockData():
         '''
         Generates a mock dataset of sheared background galaxies using the Dallas group software. 
 
-        Parameters:
-        --------
-        is_shapenoise: bool
+        Parameters
+        ----------
+        is_shapenoise: bool, optional
             If True, noise is added to the galaxy shapes
-        shapenoise: float
+        shapenoise: float, optional
             Amount of noise to add to the galaxy shapes
-        is_zerr: bool
+        is_zerr: bool, optional
             If True, a photometric redshift error is added to the background galaxy redshifts
             and a gaussian pdf is created
-        sigma_z: float
+        sigma_z: float, optional
             Width of the redshift Gaussian pdf
         '''
 

--- a/clmm/mock_data.py
+++ b/clmm/mock_data.py
@@ -7,41 +7,43 @@ from astropy.table import Table
 
 
 class MockData(): 
-    """
-    a class that generates a mock background galaxy catalog around a galaxy cluster
+    '''
+    A class that generates a mock background galaxy catalog around a galaxy cluster
     
     Attributes
     ----------
     config: dictionary
-        The configuration to generate the fake data. The cluster is located in (0,0).
-        The fields of the dictionary should be:
-        ngals: int
-            number of galaxies in the fake catalog
-        cluster_m: float
-            mass of the cluster
-        cluster_z: float
-            redshift of cluster
-        concentration: float
-            concentration of the cluster
-        src_z: float
-            redshift of background galaxies
-        cosmo: string 
-            Defines the cosmological parameter set in colossus, e.g. WMAP7-ML
-        mdef: string
-            Mass definition, e.g. '200c'
-            
+        Main properties of the mock data setup (number of galaxies, cluster mass,
+        cluster redshift, cluster concentration, source redshift, cosmo. params., 
+        mass definition)        
     catalog: astropy table
         The catalog generated given the user-defined configuration
-
-    """
+    '''
 
     
     def __init__(self, config=None):
-        """
+        '''
         Parameters
         ----------
-
-        """
+        config: dictionary
+            Main properties of the mock data setup. The cluster is located in (0,0).
+            The fields of the dictionary should be:
+            ngals: int
+                number of galaxies in the fake catalog
+            cluster_m: float
+                mass of the cluster
+            cluster_z: float
+                redshift of cluster
+            concentration: float
+                concentration of the cluster
+            src_z: float
+                redshift of background galaxies
+            cosmo: string 
+                Defines the cosmological parameter set in colossus, e.g. WMAP7-ML
+            mdef: string
+                Mass definition, e.g. '200c'     
+        '''
+        
         if config is not None:
             self.config = config
         else:
@@ -56,41 +58,41 @@ class MockData():
             
 
     def generate(self, is_shapenoise=False, shapenoise=0.005, is_zerr=False, sigma_z=0.05):
-        """
-        This generates a fake dataset of background galaxies using the Dallas group software. 
-        By default, data are perfect, i.e. no shape noise, all galaxies at the same redshift.
-        TODO: implement the shape noise, and redshift error options
+        '''
+        Generates a mock dataset of sheared background galaxies using the Dallas group software. 
 
-        Options:
+        Parameters:
         --------
-        is_shape_noise: Boolean
+        is_shapenoise: bool
             If True, noise is added to the galaxy shapes
-        is_z_err: Boolean
+        shapenoise: float
+            Amount of noise to add to the galaxy shapes
+        is_zerr: bool
             If True, a photometric redshift error is added to the background galaxy redshifts
-        
-        Returns:
-        ---------
-            astropy table containing the galaxy catalog [id, ra, dec, gamma1, gamma2, z]
-        """
+            and a gaussian pdf is created
+        sigma_z: float
+            Width of the redshift Gaussian pdf
+        '''
 
         ngals = self.config['ngals']
    
-        self.z_best = np.zeros(ngals)+self.config['src_z']
+        z_best = np.zeros(ngals)+self.config['src_z']
     
         if is_zerr:
             # introduce a redshift error on the source redshifts and generate 
             # the corresponding Gaussian pdf
             self.config['redshift_err'] = sigma_z
-            self.z_true = self.config['src_z'] + sigma_z*np.random.standard_normal(ngals)
+            z_true = self.config['src_z'] + sigma_z*np.random.standard_normal(ngals)
             zmin = self.config['src_z'] - 0.3
             zmax = self.config['src_z'] + 0.3
-            self.zbins = np.arange(zmin, zmax, 0.02)
-            self.z_pdf = np.exp(-0.5*((self.zbins - self.config['src_z'])/sigma_z)**2)/np.sqrt(2*np.pi*sigma_z**2)    
-            assert np.abs(np.trapz(self.z_pdf, self.zbins) - 1) < 1e-6
-            self.pdf_grid = np.vstack(ngals*[self.z_pdf])
+            zbins = np.arange(zmin, zmax, 0.03)
+            z_pdf = np.exp(-0.5*((zbins - self.config['src_z'])/sigma_z)**2)/np.sqrt(2*np.pi*sigma_z**2)    
+            assert np.abs(np.trapz(z_pdf, zbins) - 1) < 1e-6
+            pdf_grid = np.vstack(ngals*[z_pdf])
+            zbins_grid = np.vstack(ngals*[zbins])
         else:
             # No redshift error
-            self.z_true = self.z_best
+            z_true = z_best
 
         seqnr = np.arange(ngals)
         zL = self.config['cluster_z'] # cluster redshift
@@ -114,7 +116,7 @@ class MockData():
         x_deg = (x_mpc/Dl)*(180./np.pi) #ra
         y_deg = (y_mpc/Dl)*(180./np.pi) #dec
 
-        gamt= testProf.deltaSigma(r_mpc)/testProf.Sc(self.z_true)
+        gamt = testProf.deltaSigma(r_mpc)/testProf.Sc(z_true)
         if is_shapenoise:
             self.config['shape_noise'] = shapenoise
             gamt = gamt + shapenoise*np.random.standard_normal(ngals)
@@ -127,8 +129,8 @@ class MockData():
         e2 = -gamt*sin2phi
 
         if is_zerr:
-            self.catalog = Table([seqnr, -x_deg, y_deg, e1, e2, self.z_best, self.pdf_grid], \
-                                  names=('id', 'ra','dec','gamma1','gamma2', 'z', 'z_pdf'))
+            self.catalog = Table([seqnr, -x_deg, y_deg, e1, e2, z_best, pdf_grid, zbins_grid], \
+                                  names=('id', 'ra','dec','gamma1','gamma2', 'z', 'z_pdf', 'z_bins'))
         else:
-            self.catalog = Table([seqnr, -x_deg, y_deg, e1, e2, self.z_best], \
+            self.catalog = Table([seqnr, -x_deg, y_deg, e1, e2, z_best], \
                                 names=('id', 'ra','dec','gamma1','gamma2', 'z'))

--- a/clmm/mock_data.py
+++ b/clmm/mock_data.py
@@ -8,7 +8,7 @@ from astropy.table import Table
 
 class MockData(): 
     """
-    a class that generates a mock galaxy catalog around a galaxy cluster
+    a class that generates a mock background galaxy catalog around a galaxy cluster
     
     Attributes
     ----------
@@ -55,8 +55,8 @@ class MockData():
             self.config['concentration'] = 4
             
 
-    def generate(self,is_shape_noise=False, is_z_err=False):
-        '''
+    def generate(self, is_shapenoise=False, shapenoise=0.005, is_zerr=False, sigma_z=0.05):
+        """
         This generates a fake dataset of background galaxies using the Dallas group software. 
         By default, data are perfect, i.e. no shape noise, all galaxies at the same redshift.
         TODO: implement the shape noise, and redshift error options
@@ -71,18 +71,27 @@ class MockData():
         Returns:
         ---------
             astropy table containing the galaxy catalog [id, ra, dec, gamma1, gamma2, z]
-        '''
-
-        if is_shape_noise:
-            self.config['shape_noise'] = is_shape_noise
-
-        if is_z_err:
-            self.config['redshift_err'] = is_z_noise
-
-        if is_shape_noise or is_z_err:
-            raise ValueError('Options not implemented yet')
+        """
 
         ngals = self.config['ngals']
+   
+        self.z_best = np.zeros(ngals)+self.config['src_z']
+    
+        if is_zerr:
+            # introduce a redshift error on the source redshifts and generate 
+            # the corresponding Gaussian pdf
+            self.config['redshift_err'] = sigma_z
+            self.z_true = self.config['src_z'] + sigma_z*np.random.standard_normal(ngals)
+            zmin = self.config['src_z'] - 0.3
+            zmax = self.config['src_z'] + 0.3
+            self.zbins = np.arange(zmin, zmax, 0.02)
+            self.z_pdf = np.exp(-0.5*((self.zbins - self.config['src_z'])/sigma_z)**2)/np.sqrt(2*np.pi*sigma_z**2)    
+            assert np.abs(np.trapz(self.z_pdf, self.zbins) - 1) < 1e-6
+            self.pdf_grid = np.vstack(ngals*[self.z_pdf])
+        else:
+            # No redshift error
+            self.z_true = self.z_best
+
         seqnr = np.arange(ngals)
         zL = self.config['cluster_z'] # cluster redshift
         mdef = self.config['mdef']
@@ -105,7 +114,10 @@ class MockData():
         x_deg = (x_mpc/Dl)*(180./np.pi) #ra
         y_deg = (y_mpc/Dl)*(180./np.pi) #dec
 
-        gamt= testProf.deltaSigma(r_mpc)/testProf.Sc(self.config['src_z'])
+        gamt= testProf.deltaSigma(r_mpc)/testProf.Sc(self.z_true)
+        if is_shapenoise:
+            self.config['shape_noise'] = shapenoise
+            gamt = gamt + shapenoise*np.random.standard_normal(ngals)
 
         posangle = np.arctan2(y_mpc, x_mpc)
         cos2phi = np.cos(2*posangle)
@@ -114,5 +126,9 @@ class MockData():
         e1 = -gamt*cos2phi
         e2 = -gamt*sin2phi
 
-        self.catalog = Table([seqnr, -x_deg, y_deg, e1, e2, np.zeros(ngals)+self.config['src_z']], \
-                            names=('id', 'ra','dec','gamma1','gamma2', 'z'))
+        if is_zerr:
+            self.catalog = Table([seqnr, -x_deg, y_deg, e1, e2, self.z_best, self.pdf_grid], \
+                                  names=('id', 'ra','dec','gamma1','gamma2', 'z', 'z_pdf'))
+        else:
+            self.catalog = Table([seqnr, -x_deg, y_deg, e1, e2, self.z_best], \
+                                names=('id', 'ra','dec','gamma1','gamma2', 'z'))

--- a/clmm/mock_data.py
+++ b/clmm/mock_data.py
@@ -1,0 +1,118 @@
+import sys
+from clmm.models import CLMM_densityModels_beforeConvertFromPerH as clmm_mod
+import numpy as np
+import colossus.cosmology.cosmology as Cosmology
+import matplotlib.pyplot as plt
+from astropy.table import Table
+
+
+class MockData(): 
+    """
+    a class that generates a mock galaxy catalog around a galaxy cluster
+    
+    Attributes
+    ----------
+    config: dictionary
+        The configuration to generate the fake data. The cluster is located in (0,0).
+        The fields of the dictionary should be:
+        ngals: int
+            number of galaxies in the fake catalog
+        cluster_m: float
+            mass of the cluster
+        cluster_z: float
+            redshift of cluster
+        concentration: float
+            concentration of the cluster
+        src_z: float
+            redshift of background galaxies
+        cosmo: string 
+            Defines the cosmological parameter set in colossus, e.g. WMAP7-ML
+        mdef: string
+            Mass definition, e.g. '200c'
+            
+    catalog: astropy table
+        The catalog generated given the user-defined configuration
+
+    """
+
+    
+    def __init__(self, config=None):
+        """
+        Parameters
+        ----------
+
+        """
+        if config is not None:
+            self.config = config
+        else:
+            self.config = {}
+            self.config['ngals'] = int(3.e4)
+            self.config['cluster_m'] = 1.e15
+            self.config['cluster_z'] = 0.3
+            self.config['src_z'] = 0.8
+            self.config['cosmo'] = 'WMAP7-ML'
+            self.config['mdef'] = '200c'
+            self.config['concentration'] = 4
+            
+
+    def generate(self,is_shape_noise=False, is_z_err=False):
+        '''
+        This generates a fake dataset of background galaxies using the Dallas group software. 
+        By default, data are perfect, i.e. no shape noise, all galaxies at the same redshift.
+        TODO: implement the shape noise, and redshift error options
+
+        Options:
+        --------
+        is_shape_noise: Boolean
+            If True, noise is added to the galaxy shapes
+        is_z_err: Boolean
+            If True, a photometric redshift error is added to the background galaxy redshifts
+        
+        Returns:
+        ---------
+            astropy table containing the galaxy catalog [id, ra, dec, gamma1, gamma2, z]
+        '''
+
+        if is_shape_noise:
+            self.config['shape_noise'] = is_shape_noise
+
+        if is_z_err:
+            self.config['redshift_err'] = is_z_noise
+
+        if is_shape_noise or is_z_err:
+            raise ValueError('Options not implemented yet')
+
+        ngals = self.config['ngals']
+        seqnr = np.arange(ngals)
+        zL = self.config['cluster_z'] # cluster redshift
+        mdef = self.config['mdef']
+        cosmo = Cosmology.setCosmology(self.config['cosmo'])
+
+        M = self.config['cluster_m']*cosmo.h
+        c = self.config['concentration']  
+        r = np.linspace(0.25, 10., 1000) #Mpc
+        r = r*cosmo.h #Mpc/h
+
+        testProf = clmm_mod.nfwProfile(M = M, c = c, zL = zL, mdef = mdef, \
+                                chooseCosmology = self.config['cosmo'], esp = None)
+
+        x_mpc = np.random.uniform(-4, 4, size=ngals)
+        y_mpc = np.random.uniform(-4, 4, size=ngals)
+        r_mpc = np.sqrt(x_mpc**2 + y_mpc**2)
+
+        Dl = cosmo.angularDiameterDistance(zL)
+
+        x_deg = (x_mpc/Dl)*(180./np.pi) #ra
+        y_deg = (y_mpc/Dl)*(180./np.pi) #dec
+
+        gamt= testProf.deltaSigma(r_mpc)/testProf.Sc(self.config['src_z'])
+
+        posangle = np.arctan2(y_mpc, x_mpc)
+        cos2phi = np.cos(2*posangle)
+        sin2phi = np.sin(2*posangle)
+
+        e1 = -gamt*cos2phi
+        e2 = -gamt*sin2phi
+
+        self.catalog = Table([seqnr, -x_deg, y_deg, e1, e2, np.zeros(ngals)+self.config['src_z']], \
+                            names=('id', 'ra','dec','gamma1','gamma2', 'z'))

--- a/clmm/mock_data.py
+++ b/clmm/mock_data.py
@@ -1,5 +1,6 @@
 import sys
 from clmm.models import CLMM_densityModels_beforeConvertFromPerH as clmm_mod
+from clmm.core import CLMMBase
 import numpy as np
 import colossus.cosmology.cosmology as Cosmology
 import matplotlib.pyplot as plt

--- a/examples/fake_data_demo.ipynb
+++ b/examples/fake_data_demo.ipynb
@@ -8,11 +8,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys \n",
-    "import numpy as np\n",
-    "import colossus.cosmology.cosmology as Cosmology\n",
-    "import matplotlib.pyplot as plt\n",
-    "from astropy.table import Table"
+    "import matplotlib.pyplot as plt"
    ]
   },
   {
@@ -25,7 +21,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import clmm.mock_data as mock"
@@ -34,7 +32,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "config={}\n",
@@ -62,7 +62,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "ideal_data.generate()\n",
@@ -129,10 +131,18 @@
     "saa_noisy.compute_shear()\n",
     "saa_ideal.make_shear_profile()\n",
     "saa_noisy.make_shear_profile()\n",
-    "saa_ideal.plot_profile()\n",
-    "saa_noisy.plot_profile()\n",
     "\n",
-    "plt.show()"
+    "%matplotlib inline\n",
+    "saa_ideal.plot_profile()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "saa_noisy.plot_profile()"
    ]
   },
   {

--- a/examples/fake_data_demo.ipynb
+++ b/examples/fake_data_demo.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## This example jupyer notebook uses clmm code to generate mock data with a set of configuration parmeters, producing a catalog of ideal and noisy example data."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
@@ -34,7 +42,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Mock data generation requires a config dictionary"
+    "### Mock data generation requires a config dictionary"
    ]
   },
   {

--- a/examples/fake_data_demo.ipynb
+++ b/examples/fake_data_demo.ipynb
@@ -4,7 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
+    "### Author: Celine Combet\n",
+    "### Date Created: 5 Oct 2018\n",
     "## This example jupyer notebook uses clmm code to generate mock data with a set of configuration parmeters, producing a catalog of ideal and noisy example data."
    ]
   },

--- a/examples/fake_data_demo.ipynb
+++ b/examples/fake_data_demo.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
+    "import sys \n",
     "import numpy as np\n",
     "import colossus.cosmology.cosmology as Cosmology\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/fake_data_demo.ipynb
+++ b/examples/fake_data_demo.ipynb
@@ -1,0 +1,119 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import numpy as np\n",
+    "import colossus.cosmology.cosmology as Cosmology\n",
+    "import matplotlib.pyplot as plt\n",
+    "from astropy.table import Table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Import mock data module and setup the configuration "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import clmm.mock_data as mock"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config={}\n",
+    "config['cluster_m'] = 1.e15\n",
+    "config['cluster_z'] = 0.3\n",
+    "config['src_z'] = 0.8\n",
+    "config['concentration'] = 4\n",
+    "config['cosmo'] = 'WMAP7-ML'\n",
+    "config['ngals'] = 10000\n",
+    "config['mdef'] = '200c'\n",
+    "\n",
+    "my_data = mock.MockData(config=config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generate the mock catalog from the configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_data.generate()\n",
+    "my_data.catalog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compute and plot shear profile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from clmm import ShearAzimuthalAverager"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cl_dict = {'z':config['cluster_z'], 'ra':0.0, 'dec': 0.0}\n",
+    "saa = ShearAzimuthalAverager(cl_dict,my_data.catalog)\n",
+    "saa.compute_shear()\n",
+    "shear_prof = saa.make_shear_profile()\n",
+    "saa.plot_profile()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "desc-clmassmod",
+   "language": "python",
+   "name": "desc-clmassmod"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/fake_data_demo.ipynb
+++ b/examples/fake_data_demo.ipynb
@@ -2,13 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
    ]
   },
   {
@@ -20,9 +21,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -30,8 +31,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mock data generation requires a config dictionary"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "collapsed": true
    },
@@ -61,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "collapsed": true
    },
@@ -73,9 +81,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "&lt;Table length=10000&gt;\n",
+       "<table id=\"table140388691946632\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>id</th><th>ra</th><th>dec</th><th>gamma1</th><th>gamma2</th><th>z</th></tr></thead>\n",
+       "<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th></tr></thead>\n",
+       "<tr><td>0</td><td>0.22229783067</td><td>-0.136796055602</td><td>-0.00398336307623</td><td>-0.00789051857411</td><td>0.8</td></tr>\n",
+       "<tr><td>1</td><td>0.155922740062</td><td>-0.25563956524</td><td>0.00334372838078</td><td>-0.00649522920953</td><td>0.8</td></tr>\n",
+       "<tr><td>2</td><td>-0.128151059278</td><td>-0.252624337966</td><td>0.00466310622072</td><td>0.0063702677062</td><td>0.8</td></tr>\n",
+       "<tr><td>3</td><td>-0.025337931365</td><td>-0.0643041543786</td><td>0.030584455732</td><td>0.0285325557326</td><td>0.8</td></tr>\n",
+       "<tr><td>4</td><td>-0.309800086125</td><td>-0.182037922764</td><td>-0.0027423147836</td><td>0.00492228052874</td><td>0.8</td></tr>\n",
+       "<tr><td>5</td><td>-0.309112863719</td><td>-0.172467667019</td><td>-0.00302409519814</td><td>0.00489989676827</td><td>0.8</td></tr>\n",
+       "<tr><td>6</td><td>-0.235491369972</td><td>-0.289266612636</td><td>0.00108264421412</td><td>0.00522694136732</td><td>0.8</td></tr>\n",
+       "<tr><td>7</td><td>0.212040369099</td><td>0.0221039042058</td><td>-0.0113554936229</td><td>0.00239349025591</td><td>0.8</td></tr>\n",
+       "<tr><td>8</td><td>-0.196199898522</td><td>0.279653999882</td><td>0.00206202776301</td><td>-0.00569800729889</td><td>0.8</td></tr>\n",
+       "<tr><td>9</td><td>-0.0898878709476</td><td>0.0558332838796</td><td>-0.0120259776721</td><td>-0.0243246405835</td><td>0.8</td></tr>\n",
+       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
+       "<tr><td>9990</td><td>-0.238926732198</td><td>0.0628983845375</td><td>-0.00829180059851</td><td>-0.00469078027486</td><td>0.8</td></tr>\n",
+       "<tr><td>9991</td><td>-0.242788264754</td><td>0.0126249631894</td><td>-0.00968456566702</td><td>-0.00100992353077</td><td>0.8</td></tr>\n",
+       "<tr><td>9992</td><td>-0.126586255078</td><td>-0.0122515436844</td><td>-0.0216397811008</td><td>0.00422838384125</td><td>0.8</td></tr>\n",
+       "<tr><td>9993</td><td>0.124231381653</td><td>-0.0542940350717</td><td>-0.0138958605259</td><td>-0.0150137669341</td><td>0.8</td></tr>\n",
+       "<tr><td>9994</td><td>0.016059278626</td><td>-0.1174037763</td><td>0.0230356605653</td><td>-0.00642210688877</td><td>0.8</td></tr>\n",
+       "<tr><td>9995</td><td>-0.275259110203</td><td>0.0370917154408</td><td>-0.00782402312019</td><td>-0.00214760188964</td><td>0.8</td></tr>\n",
+       "<tr><td>9996</td><td>-0.316336249014</td><td>0.0205217777031</td><td>-0.00668459507393</td><td>-0.000870969051971</td><td>0.8</td></tr>\n",
+       "<tr><td>9997</td><td>-0.131212136323</td><td>-0.14761280902</td><td>0.00150358234996</td><td>0.0127368483691</td><td>0.8</td></tr>\n",
+       "<tr><td>9998</td><td>-0.0828757352019</td><td>0.257247972903</td><td>0.00684102544801</td><td>-0.00491831466787</td><td>0.8</td></tr>\n",
+       "<tr><td>9999</td><td>-0.0333360889448</td><td>0.0383074534406</td><td>0.00755233283981</td><td>-0.0541572231444</td><td>0.8</td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Table length=10000>\n",
+       "  id         ra              dec        ...       gamma2          z   \n",
+       "int64     float64          float64      ...      float64       float64\n",
+       "----- ---------------- ---------------- ... ------------------ -------\n",
+       "    0    0.22229783067  -0.136796055602 ...  -0.00789051857411     0.8\n",
+       "    1   0.155922740062   -0.25563956524 ...  -0.00649522920953     0.8\n",
+       "    2  -0.128151059278  -0.252624337966 ...    0.0063702677062     0.8\n",
+       "    3  -0.025337931365 -0.0643041543786 ...    0.0285325557326     0.8\n",
+       "    4  -0.309800086125  -0.182037922764 ...   0.00492228052874     0.8\n",
+       "    5  -0.309112863719  -0.172467667019 ...   0.00489989676827     0.8\n",
+       "    6  -0.235491369972  -0.289266612636 ...   0.00522694136732     0.8\n",
+       "    7   0.212040369099  0.0221039042058 ...   0.00239349025591     0.8\n",
+       "    8  -0.196199898522   0.279653999882 ...  -0.00569800729889     0.8\n",
+       "    9 -0.0898878709476  0.0558332838796 ...   -0.0243246405835     0.8\n",
+       "  ...              ...              ... ...                ...     ...\n",
+       " 9990  -0.238926732198  0.0628983845375 ...  -0.00469078027486     0.8\n",
+       " 9991  -0.242788264754  0.0126249631894 ...  -0.00100992353077     0.8\n",
+       " 9992  -0.126586255078 -0.0122515436844 ...   0.00422838384125     0.8\n",
+       " 9993   0.124231381653 -0.0542940350717 ...   -0.0150137669341     0.8\n",
+       " 9994   0.016059278626    -0.1174037763 ...  -0.00642210688877     0.8\n",
+       " 9995  -0.275259110203  0.0370917154408 ...  -0.00214760188964     0.8\n",
+       " 9996  -0.316336249014  0.0205217777031 ... -0.000870969051971     0.8\n",
+       " 9997  -0.131212136323   -0.14761280902 ...    0.0127368483691     0.8\n",
+       " 9998 -0.0828757352019   0.257247972903 ...  -0.00491831466787     0.8\n",
+       " 9999 -0.0333360889448  0.0383074534406 ...   -0.0541572231444     0.8"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ideal_data.catalog"
    ]
@@ -91,9 +164,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "&lt;Table length=10000&gt;\n",
+       "<table id=\"table140388691947360\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>id</th><th>ra</th><th>dec</th><th>gamma1</th><th>gamma2</th><th>z</th><th>z_pdf [21]</th><th>z_bins [21]</th></tr></thead>\n",
+       "<thead><tr><th>int64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th></tr></thead>\n",
+       "<tr><td>0</td><td>-0.321694350478</td><td>-0.345450890553</td><td>0.000578962916806</td><td>0.00811908169959</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>1</td><td>-0.285857533476</td><td>-0.213917868169</td><td>-0.00108716710291</td><td>0.00369810903918</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>2</td><td>0.281652523536</td><td>-0.267147937149</td><td>-0.000417486647861</td><td>-0.00789256635045</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>3</td><td>0.230919221089</td><td>0.110567236538</td><td>-0.00831472967508</td><td>0.0103308945229</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>4</td><td>-0.251646033493</td><td>-0.182446288799</td><td>-0.000165895170253</td><td>0.000507110104629</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>5</td><td>0.00725104806794</td><td>-0.0176168856655</td><td>0.0743591310992</td><td>-0.0736970527257</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>6</td><td>-0.201419835861</td><td>-0.291540697832</td><td>0.00137264877792</td><td>0.00362871919495</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>7</td><td>0.239132423973</td><td>-0.229901693426</td><td>-0.000274957470349</td><td>-0.00698289718397</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>8</td><td>0.191418480776</td><td>-0.194432531923</td><td>0.000116929061262</td><td>-0.00748402092667</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>9</td><td>0.115594479276</td><td>-0.315042658692</td><td>0.00324288524066</td><td>-0.00274996062665</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
+       "<tr><td>9990</td><td>-0.296952207258</td><td>0.029291854685</td><td>-0.00748130268729</td><td>-0.00149043825578</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>9991</td><td>-0.192701017837</td><td>-0.176264240885</td><td>-0.000904021918528</td><td>0.0101263991582</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>9992</td><td>-0.238577938985</td><td>0.058021748815</td><td>-0.000130581409561</td><td>-6.7507087781e-05</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>9993</td><td>-0.224782848321</td><td>0.0430679327747</td><td>-0.00404904848492</td><td>-0.00161070748047</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>9994</td><td>-0.225700099464</td><td>-0.0166008031802</td><td>-0.00961632045971</td><td>0.00142230314731</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>9995</td><td>0.265270696179</td><td>0.31105883441</td><td>-0.000293380333053</td><td>-0.00183471643849</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>9996</td><td>-0.243462069664</td><td>0.191705358785</td><td>-0.00317777249384</td><td>-0.0131702891189</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>9997</td><td>-0.216295573672</td><td>0.0569786020179</td><td>-0.0110968289826</td><td>-0.00628243023642</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>9998</td><td>0.170154129333</td><td>-0.139390686425</td><td>-0.0038319624905</td><td>-0.01908837779</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "<tr><td>9999</td><td>0.130498275168</td><td>-0.125843854743</td><td>-0.000542331714934</td><td>-0.0149295316574</td><td>0.8</td><td>1.21517656996e-07 .. 1.21517656996e-07</td><td>0.5 .. 1.1</td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Table length=10000>\n",
+       "  id         ra        ...               z_pdf [21]               z_bins [21]\n",
+       "int64     float64      ...                float64                   float64  \n",
+       "----- ---------------- ... -------------------------------------- -----------\n",
+       "    0  -0.321694350478 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       "    1  -0.285857533476 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       "    2   0.281652523536 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       "    3   0.230919221089 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       "    4  -0.251646033493 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       "    5 0.00725104806794 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       "    6  -0.201419835861 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       "    7   0.239132423973 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       "    8   0.191418480776 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       "    9   0.115594479276 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       "  ...              ... ...                                    ...         ...\n",
+       " 9990  -0.296952207258 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       " 9991  -0.192701017837 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       " 9992  -0.238577938985 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       " 9993  -0.224782848321 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       " 9994  -0.225700099464 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       " 9995   0.265270696179 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       " 9996  -0.243462069664 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       " 9997  -0.216295573672 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       " 9998   0.170154129333 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1\n",
+       " 9999   0.130498275168 ... 1.21517656996e-07 .. 1.21517656996e-07  0.5 .. 1.1"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "noisy_data.catalog"
    ]
@@ -107,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "collapsed": true
    },
@@ -118,9 +256,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/babyostrich/anaconda3/lib/python3.5/site-packages/astropy/table/row.py:56: FutureWarning: elementwise == comparison failed and returning scalar instead; this will raise an error or perform elementwise comparison in the future.\n",
+      "  return self.as_void() == other\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "read g1, g2 directly\n",
+      "read g1, g2 directly\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX4AAAEKCAYAAAAVaT4rAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xl8FfW9//HXJycJYQkJJGFNkKCIBgHRsLlQsNJCXai2\nFVyrXVBbq12s9Xd/tffXW723t94uWq2ISK21FbBVL3UtVVoUCRAQAQlKDGiCEMIWCAghyff3x5lg\njIEM5OQsmffz8TgPzpn5njOfHMf3zJn5znfMOYeIiARHUqwLEBGR6FLwi4gEjIJfRCRgFPwiIgGj\n4BcRCRgFv4hIwCj4RUQCRsEvIhIwCn4RkYBJjnUBLcnOznYDBw6MdRkiIglj5cqVO5xzOX7axmXw\nDxw4kOLi4liXISKSMMzsfb9tdahHRCRgFPwiIgGj4BcRCZi4PMYvItIeDh8+TEVFBQcPHox1KScs\nLS2N3NxcUlJSTvgzFPwiEhgVFRWkp6czcOBAzCzW5Rw35xw7d+6koqKC/Pz8E/4cHeoRkcA4ePAg\nWVlZCRn6AGZGVlZWm3+xKPhFJFASNfQbRaJ+Bb+IyDFMe3gp0x5eGusyIqpDBX9H/A8kIhJpHSr4\nRUSkdQp+EZEoKykpYfz48QwfPpx7772XU045JarLV3dOEQmkn/7tbdZ/uLfVduu3htv4OYxc0K87\n/37J0GO2qaur4+qrr+bRRx9l5MiR3HzzzZxxxhkA7N69mx49eviovm20xy8iEkVPP/00I0aMYOTI\nkQAUFBQwYsQIAL73ve9FpQbt8YtIILW2Z96ocU9/3o3jIrLcNWvWcOaZZx55vW7dOiZPnsxLL73E\nhg0buPfee/nhD38YkWUdjfb4RUSiKCsri3fffReA1atX88QTTzBixAiys7O55ppr2j30QcEvIhJV\n1157LcXFxQwbNoxHH32UgQMHMmjQINasWXPkkE97U/CLiERRWloay5YtY+3atQwYMIDLLrsMgOzs\nbGbPnk1JSUm716Bj/CIixxCpY/uNfv3rXzN37lxSUlI499xz+dWvfgXApZdeyqWXXhrRZR2Ngl9E\nJIruuusu7rrrrpjW0KEO9ew7eJi6BhfrMkRE4lqH2ePfvb+WDdv20Tk1RPWBw2R0OfGbFIiIdGS+\n9vjNbLKZvWNmpWZ2Zwvzzczu9+avMbOzmszbbGZrzWy1mRVHsvimenRN5eScbhw4VM9Vs4vYvb+2\nvRYlIpLQWg1+MwsBDwJTgALgSjMraNZsCjDYe8wAHmo2f6Jz7kznXGHbSz66nl1TObV3NzZur+HK\nR4qo2neoPRcnIpKQ/OzxjwZKnXNlzrlaYC4wtVmbqcDjLqwIyDSzvhGu1ZfMLqn8/vpRbN65n+mz\nllK5N3HvrSki0h78BH9/oLzJ6wpvmt82DviHma00sxlHW4iZzTCzYjMrrqqq8lHW0Z17SjZ/uGE0\n26oPcsXDS9my56M2fZ6IBNjvLwo/OpBo9Oo5zzl3JuHDQd82s/EtNXLOzXLOFTrnCnNyctq80DGD\nsvjjN8awa38t0x5eSvmuA23+TBGRjsBP8G8B8pq8zvWm+WrjnGv8dzvwDOFDR1Fx1oAe/PkbY9l3\nsI4rHl5KWVVNtBYtIhK3/AT/CmCwmeWbWSowHVjQrM0C4Dqvd89YoNo5t9XMuppZOoCZdQU+B6yL\nYP2tGpabwZPfHEttXQPTZhWxsXJfNBcvIvIpcX8jFudcnZndArwMhIA5zrm3zewmb/5M4AXgC0Ap\ncAC4wXt7b+AZ767wycCfnXMvRfyvaEVBv+7MnTGWq2YvY9qsIp74+hgK+nWPdhkiEk9evBO2rW29\n3bY14X/9HOfvMwym/PyYTY51I5Zo8XUBl3PuBcLh3nTazCbPHfDtFt5XBkRnuLlWDO6dzvwbx3HV\nI0Vc+UgRf/z6aIbnZsa6LBEJmJZuxNKrV68j86urq8nIyPjU80jqMFfu+pGf3ZX5N47jykeKuPqR\nZfzh66M5a0D73+ZMROJQK3vmRzTu6d/wfEQWe7QbsTS6/fbbufXWW6msrGTRokXcc889EVluUx1q\nrB4/8np2Yd6N48jqlsq1s5exfNOuWJckIgFytBuxNHrggQf48Y9/zJNPPsndd9/dLjUELvgB+md2\nZt6N4+iTkcZX5yxnSemOWJckIgFxtBuxNFq+fDm5ubnU1dUd2UBEWocK/nk3jvM9dnbv7mnMu3Ec\nJ2V14YbHVrDone3tXJ2IyNFvxNJo2bJl/Pa3v2XmzJm8/PLL7VKDhc/LxpfCwkJXXNxu47l9wu79\ntVw7ZxnvbqvhgatG8rmhfaKyXBGJvpKSEk4//fSY1vCzn/3sUzdi6dSp03F9Rkt/h5mt9DseWuCD\nH6D6o8N8dc5y1m2p5r7pI7loeEyGGRKRdhYPwR8JbQ3+DnWo50RldE7hj18fzcgBmXznyVU882ZF\nrEsSEWk3Cn5PeloKf/jaaMYOyuL7899i/ory1t8kIpKAFPxNdElNZs71oxg/OIc7/rqGPxa9H+uS\nRCTC4vHw9vGIRP0K/mbSUkLMuu5sLjy9F3c9u47Zr5XFuiQRiZC0tDR27tyZsOHvnGPnzp2kpaW1\n6XMCdeWuX52SQ/zu6rO5be6b3P18CbX1DXxrQnQHURKRyMvNzaWiooK23vMjltLS0sjNzW3TZyj4\njyI1OYnfXjmSHzz1Fr946R0OHW7guxcOxhtwTkQSUEpKCvn5+bEuI+YU/MeQHEriV1ecSUooifte\n2UhtfQN3fH6Iwl9EEpqCvxWhJOMXXxpOanISD/3zPQ4dbuCui09X+ItIwlLw+5CUZNzzxTPolJzE\nnCWbqK2v5z8uPYOkJIW/iCQeBb9PZsZPLi4gNTmJh/9VRm1dA/91+XBCCn8RSTAK/uNgZtw5+TQ6\nJYe4/5WN1NY18D9fGUFySL1iRSRxKPiPk5nx/Umn0ik5iXtffofa+gbumz6SlBbCf9rDSwF8jxgq\nIhINCv4T9O2Jp9ApOSncz79uFQ9ePZJOyaFYlyUi0iodo2iDb5w/iP+YOpR/lFQy4/GVHDxcH+uS\nRERapeBvo+vGDeTnlw9j8cYqvvbYCg7U1sW6JBGRY1LwR8D00QP45VdGUFS2k6/OWc6+g4djXZKI\nyFEp+CPk8rNyuf/Kkaz6YA/XPrqc6o8U/iISn3RyN4IuHt6PlFASt/x5FVfPLiI1lNRibx8RkVhS\nKkXY54f2Yda1hbxbWUPJ1n0crm+IdUkiIp+g4G8HE0/rxZyvjuJQXT3rt+5l/Yd7Y12SiMgRCv52\nct7gbIb0Sae+wfHFB5cwa/F7NDQk5s0fRKRj8RX8ZjbZzN4xs1Izu7OF+WZm93vz15jZWc3mh8zs\nTTN7LlKFJ4LuaSkM65/BxNNy+M8XNnDV7CK27Pko1mWJSMC1GvxmFgIeBKYABcCVZlbQrNkUYLD3\nmAE81Gz+bUBJm6tNQCmhJGZecza/+PJw1lZUM/k3i/nf1VtiXZaIBJifPf7RQKlzrsw5VwvMBaY2\nazMVeNyFFQGZZtYXwMxygYuA2RGsO6GYGVcU5vHibeM5tXc6t81dzXeefJPqA+ryKSLR5yf4+wPl\nTV5XeNP8tvkNcAcQ+O4tA7K6MG/GWG7/3Km8uHYrk+9bzBulO2JdlogETLue3DWzi4HtzrmVPtrO\nMLNiMytO5BshtyY5lMQtFwzm6W+dQ+fUEFfNXsbPnluvcX5EJGr8BP8WIK/J61xvmp825wKXmtlm\nwoeILjCzJ1paiHNulnOu0DlXmJOT47P8xDU8N5Pnv3M+1449iUdf38TUB5ZQslXdPkWk/fkJ/hXA\nYDPLN7NUYDqwoFmbBcB1Xu+esUC1c26rc+7/OOdynXMDvfe96py7JpJ/QCLrnBriZ188g99fP4qd\n+2uZ+oC6fYpI+2s1+J1zdcAtwMuEe+bMd869bWY3mdlNXrMXgDKgFHgE+FY71dshTTytFy9/93wm\nDAl3+7x69jI+VLdPEWkn5lz87V0WFha64uLiWJcRdc45niqu4Kd/e5ukJOPuL57B1DObn0cXEfk0\nM1vpnCv001ZX7sYRM+OKUXm8cNv5DO7VjdvmruZWdfsUkQhT8Mehk7K6Mv/Gcfxg0qm8oG6fIhJh\nCv44lRxK4jufHcxfbz6Hzinhbp/3PL+eQ3Xq9ikibaPgj3Mj8jJ57tbzuGbsAB55Ldztc8M2dfsU\nkROn4E8AXVKTufuLw/j99aPYUVPLpb9dwuzXytTtU0ROiII/gTR2+/zMkBzufr6Eax5Vt08ROX4K\n/gST1a0Ts649m//+0jBWl+9h8m8Ws+CtD2NdlogkEAV/AjIzpo0awIu3nc8pvbpx65NvctvcN3WD\ndxHxRcGfwBq7fX5/0qk8t2YrU36zmDfeU7dPETk2BX+CSw4lcetnB/P0zeeQlhLianX7FJFWKPg7\niMZun1ePab3b57SHlzLt4aVRrlBE4oWCvwNp7PY55/pCdtQcUrdPEWmRgr8DuuC03rz83fHq9iki\nLVLwd1Dq9ikiR5Mc6wKk/TR2+xyTn8X35odH+nylpJK6+gaSQ9rmiwSV/u8PgIHZXXmqSbfPtVv2\nqs+/SIAp+AOisdvnX28+hySDDdv28Y0/rODtD6tjXZqIRJmCP2DOzMvkjP4Z5PbozPJNu7jo/tf5\n1p9WsrFyX6xLE5EoUfAHUCjJ6J/Zmdd+dAG3fnYwi9/dwed+s5jvzVvN5h37Y12eiLQzBX+AZXRO\n4fuTTuW1OyZy4/iTeXHdVj77q3/xo7+soWL3gViXJyLtRMEv9Oiayp1TTmPxHRO5btxJPPPmFib+\nzz+569l1VO49GOvyRCTCFPxyRK/0NP79kqH8644JXFGYx5PLP2D8LxZx93Pr2VFzKNbliUiEKPjl\nU/pmdOaey4ax6PYJXDKiH3OWbGL8Lxbxi5c2sOdAbazLE5E2MufibxyXwsJCV1xcHOsyxPNeVQ33\n/WMjf1vzId1Sk/nG+YP42nkDSU9LiXVpIuIxs5XOuUJfbRX84teGbXv59cJ3efntSjK7pHDj+JP5\n6jkn0SVVF4CLxJqCX9rV2opqfrXwHRa9U0V2t1RunnAKV48ZQFpKKNaliQSWgl+iYuX7u/jl39/l\njfd20qd7GrdccApXFOaRmqxTRyLRdjzB7+v/UDObbGbvmFmpmd3Zwnwzs/u9+WvM7CxvepqZLTez\nt8zsbTP76fH9KRLPzj6pJ3/+5lj+/M0x5PbozI+fXccFv/wn84vLqatviHV5InIUrQa/mYWAB4Ep\nQAFwpZkVNGs2BRjsPWYAD3nTDwEXOOdGAGcCk81sbIRqlzhxzsnZPHXTOB67YRQ9uqRyx1/WMOnX\ni/nf1Vt0ExiROORnj380UOqcK3PO1QJzganN2kwFHndhRUCmmfX1Xtd4bVK8h5KgAzIzJgzpxYJb\nzmXWtWfTKTmJ2+auZvJ9i3lp3Vbi8ZCiSFD5Cf7+QHmT1xXeNF9tzCxkZquB7cBC59yyEy9X4p2Z\n8bmhfXjh1vP57ZUjqWtw3PTEKi554HUWbdiuDYBIHGj3s3DOuXrn3JlALjDazM5oqZ2ZzTCzYjMr\nrqqqau+ypJ0lJRmXjOjH3787nl9+ZQTVHx3mhsdWcPlDb7CkdIc2ACIx5Cf4twB5TV7netOOq41z\nbg+wCJjc0kKcc7Occ4XOucKcnBwfZUkiSA4l8aWzc3n1BxP4z8uGsa36IFfPXsaVjxSxYvOuo75v\n2sNLmfbw0ihWKhIcfoJ/BTDYzPLNLBWYDixo1mYBcJ3Xu2csUO2c22pmOWaWCWBmnYFJwIYI1i8J\nIiWUxFVjBrDo9gn8v0sKKN2+n6/MXMp1c5bzVvmeWJcnEiitXnLpnKszs1uAl4EQMMc597aZ3eTN\nnwm8AHwBKAUOADd4b+8L/MHrGZQEzHfOPRf5P0MSRVpKiOvPzWfaqAH8sWgzD/3zPaY+uIQLT+/N\n9yedSkG/7rEuUaTD0wVcElM1h+r4/eubmPVaGfsO1nHR8L5878LB/N9n1gEw78ZxMa5QJDEczwVc\nGmRFYqpbp2S+89nBXDduILNfL2PO65t4ce1WenZNpW9GWqzLE+mQdG29xIWMLin84HNDWHzHRL5x\n/iB27q9l7Za9XP67JcxfUc7+Q3WxLlGkw9ChHolLl/9uCTtqDpGaHKJ0ew1dU0NcemY/po0awIjc\nDMws1iWKxBUd6pGElxJKom9GZ+bOGMuqD3Yzd3k5z775IU8uL+e0PulMG5XHZSP7k9klNdaliiQc\nBb/ENTPj7JN6cvZJPfnJJQX87a2tzFvxAT/923r+68UNTB7ah+mj8hg7KIukJP0KEPFDwS8JIz0t\nhavGDOCqMQNY/+Fe5heX8/SqCha89SEDenZh2qg8vnx2Lr2766SwyLHoGL8ktIOH63n57W3MXV7O\n0rKdJBlccFovpo0awMQhOSSH1H9BgkE3YpFA2rxjP/OLy3lqZQVV+w7RK70TXz47lysK8xiY3TXW\n5Ym0KwW/BFpdfQOL3qli3ooPWPROFfUNjnGDspg+Oo/PD+2jW0RKh6TgF/FU7j3IX1ZWMG9FOR/s\nOkBG5xQuG9mfaaPyOL2vhoeQjkPBL9JMQ4OjqGwn84rLeXHdNmrrGhiRm8G0UQO4ZERf0tNSYl2i\nSJso+EWOYc+BWp59cwtzV5SzYds+OqeEuHh4X6aPzuOsAT10cZgkJAW/iA/OOdZUVDN3RTkLVm9h\nf209p/TqxnTv4rCsbp0+9Z7GewRo8DiJN7pyV8QHM2NEXiYj8jL58UWn8/zarcxbUc7dz5fw3y9t\nYFJBb6aPGsB5p2Tr4jDpUBT8IkDXTslcUZjHFYV5bKzcx7wV5fx1VQUvrN1G/8zOXFGYx1cKc2Nd\npkhE6FCPyFEcqqvnH+u3M3fFB7xeugOA7mkpZHdL5elvnUtGZ50QlvihY/wiEVa+6wBPraxg5j/f\no7a+geQkY8ygnkw6vTcXFvQmt0eXWJcoAafgF2knV8x8g5pD9XxmSA4L11dSur0GgIK+3ZlU0JtJ\nBb0Z2q+7egZJ1Onkrkg7MTPS05L50eTT+NHk09i0Yz8L129j4fpKfvvqRu57ZSP9MtK40NsIjMnP\nIjVZ4wVJfFHwi7RBfnZXZow/mRnjT2ZnzSFe3bCdhesrmV9czuNL3ye9UzITTuvFhaf3YsKQXjov\nIHFBh3pE2sHBw/W8vnEHC9dX8sqGSnbU1JKcZIwdlMWkgvB5gf6ZnWNdpnQgOsYvEkfqGxyry3ez\ncP12Fq7fxntV+wEY2q87F56u8wISGQp+kThWVlXDwvWVLFxfycoPduMc9M/szIWn92JSQR/GDOpJ\niu4jIMdJwS+SIHbUHOLVku0sLKnktY1VHDzcQHpaMhOH9OLCgt5MGJJDdw0gJz4o+EUS0Ee19bxe\nuoOF67fxSsl2du6vJSXU5LzA6b3pp/MCchQKfpEEV9/gePOD3SwsCR8SKvPOC5zR/+PzAgV9w+cF\nNHCcgIJfpMN5r8l5gVVNzgtMKuhNUdlO0tOSeeqmc2JdpsSQgl+kA6vad4hXN1SycP12XttYxaG6\nBsxgbH4WYwdlMWZQT87My9QtJgMm4sFvZpOB+4AQMNs59/Nm882b/wXgAHC9c26VmeUBjwO9AQfM\ncs7d19ryFPwi/nxUW8/UB15n78HD9OzaiZJte3EOUpOTODMvk7H5PRk7KIuRA3rQOVUbgo4sokM2\nmFkIeBCYBFQAK8xsgXNufZNmU4DB3mMM8JD3bx3wA28jkA6sNLOFzd4rIieoc2qIHl1T6dE1lXk3\njqP6wGFWbN7Fsk07KSrbxQOLSrn/1VJSQsaI3EzGDOrJmPwszj6pB1076cL9oPLzX340UOqcKwMw\ns7nAVKBpeE8FHnfhnw9FZpZpZn2dc1uBrQDOuX1mVgL0b/ZeEYmQjC4pXOhdGQyw9+BhVm7eTdGm\nnSwr28XMf5Xx4KL3SE4yhuVmMCY/fGio8KQeuu9wgPgJ/v5AeZPXFYT35ltr0x8v9AHMbCAwEljW\n0kLMbAYwA2DAgAE+yhIROHZvnu5pKUw8rRcTT+sFQM2hOla+v5tlZTtZtmkXj75exsx/vUeSwRn9\nM8LnCPJ7Ujiwp8YV6sCi8lvPzLoBfwW+65zb21Ib59wsYBaEj/FHoy6RoOnWKZnPnJrDZ07NAcLn\nCFZ9EN4QFJXt4rElm5m1uAyz8FDTY/KzGDuoJ6Pze5LZJTXG1Uuk+An+LUBek9e53jRfbcwshXDo\n/8k59/SJlyoikdY5NcS5p2Rz7inZQHhwuTc/2MMy79DQn5a9z5wlmzCDIb3Tj/wiGJ3fs8Wb0Uti\n8BP8K4DBZpZPOMynA1c1a7MAuMU7/j8GqHbObfV6+zwKlDjnfhXBukWkHaSlhBh3chbjTs4Cwref\nfKu8+sihoXkrynnsjc0AnNq725FzBGPys8hJ14YgUfjtzvkF4DeEu3POcc7dY2Y3ATjnZnoB/wAw\nmXB3zhucc8Vmdh7wGrAWaPA+7t+ccy8ca3nqzikSn2rrGli7ZQ9FZbtYtmkXKzfvYn9tPQCDcroe\n+UUwdlAWvbun6ariKNIFXCISFXX1Daz7cC9FZTtZVraT4s272XeoDoCBWV3Yf6ie9LRkHrrmbE7O\n6UqyRh1tNwp+EYmJ+gbH+g/3etcR7GTRO1XUN4QzJi0liYK+3Rmem8kZ/TMY1j+DU3p1I5Sk+xBE\ngoJfROLCFTPf4ODhBm44byBrK/aydsse3v5wLwe8w0OdU0IU9OvOMG9DMCw3g5NztDE4EbrZuojE\nBTOjc2qIy0bmctnI8LT6BkdZVQ1rt1SHHxXVnzhp3CU1REHf7gzLzTiyQRikjUFEaY9fRGKuvsHx\nXlUNayuqj2wQ1n+4l48Oh38ZdEkNMbRfd4b1z2RYbvgXQn62NgZN6VCPiCS8uvoG3qvaz9ot1azb\nUs2aij2s37qXg4fDHQS7poYY2i/jyC+DM/pnMCi7K0kB3RjoUI+IJLzkUBJD+qQzpE86Xz47F/h4\nY7CmYk94Y7ClmieK3udQXXhj0K1T8pFzBsNzwxuD/KzgbgyORnv8IpLQ6uobKK2qYU1F4y+Dakq2\n7v3ExmBo4wlk79fBnX9dg5l1qOsLdKhHRALtcH0Dpds/PmewZkt4Y1DrbQxC3knni4f35ZRe3Ti1\ndzqn9k6nd/dOhK9HTTwKfhGRZg7XN7Cxsoa1W/bwy7+/y0eH60kJJbFrf+2RNulpyQz2NgSDe6cf\neZ4IGwQd4xcRaSYllERBv+4U9OvO06vC40zOu3EcO2oOsbGyho3b9/Fu5T42Vtbw9/WVzF3x8Ujz\nibxBaIn2+EVEWtDSBmHj9pq4/YWgPX4RkTbK7taJ7G6djoxU2qgj/EJQ8IuIHIdjbRDerdxH6fYa\n3q3cx7uVNbz89jbfG4Tps4qA6IxkquAXEYmAxg3COSdnf2K63w2Cc+ErlJ1z7f6rQMEvItKO/G4Q\n/nf1hxyorYvKoSAFv4hIDDTfIGysrInashX8IiJxIJpXEet2OCIiAaPgFxEJGAW/iEjAKPhFRAJG\nwS8iEjAKfhGRgFHwi4gEjIJfRCRgFPwiIgGj4BcRCRhfwW9mk83sHTMrNbM7W5hvZna/N3+NmZ3V\nZN4cM9tuZusiWbiIiJyYVoPfzELAg8AUoAC40swKmjWbAgz2HjOAh5rMewyYHIliRUSk7fzs8Y8G\nSp1zZc65WmAuMLVZm6nA4y6sCMg0s74AzrnFwK5IFi0iIifOT/D3B8qbvK7wph1vGxERiQNxc3LX\nzGaYWbGZFVdVVcW6HBGRDstP8G8B8pq8zvWmHW+bY3LOzXLOFTrnCnNyco7nrSIichz8BP8KYLCZ\n5ZtZKjAdWNCszQLgOq93z1ig2jm3NcK1iohIBLQa/M65OuAW4GWgBJjvnHvbzG4ys5u8Zi8AZUAp\n8Ajwrcb3m9mTwFJgiJlVmNnXI/w3iIjIcTDnXKxr+JTCwkJXXFwc6zJERBKGma10zhX6aRs3J3dF\nRCQ6FPwiIgGj4BcRCRgFv4hIwCj4RUQCRsEvIhIwCn4RkYBR8IuIBIyCX0QkYBT8IiIBo+AXEQkY\nBb+ISMAo+EVEAkbBLyISMAp+EZGAUfCLiASMgl9EJGAU/CIiAaPgFxEJGAW/iEjAKPhFRAJGwS8i\nEjAKfhGRgFHwi4gEjIJfRCRgFPwiIgGj4BcRCRhfwW9mk83sHTMrNbM7W5hvZna/N3+NmZ3l970i\nIhJdrQa/mYWAB4EpQAFwpZkVNGs2BRjsPWYADx3He0VEJIr87PGPBkqdc2XOuVpgLjC1WZupwOMu\nrAjINLO+Pt8rIiJRlOyjTX+gvMnrCmCMjzb9fb43cl68E7atbbePFxFpV32GwZSft/ti4ubkrpnN\nMLNiMyuuqqqKdTkiIh2Wnz3+LUBek9e53jQ/bVJ8vBcA59wsYBZAYWGh81HXp0VhSykikuj87PGv\nAAabWb6ZpQLTgQXN2iwArvN694wFqp1zW32+V0REoqjVPX7nXJ2Z3QK8DISAOc65t83sJm/+TOAF\n4AtAKXAAuOFY722Xv0RERHwx507sqEp7KiwsdMXFxbEuQ0QkYZjZSudcoZ+2cXNyV0REokPBLyIS\nMAp+EZGAUfCLiASMgl9EJGDislePmVUB78ewhGxgRwyXfzTxWhfEb22q6/jFa22q69hOcs7l+GkY\nl8Efa2ZW7LdbVDTFa10Qv7WpruMXr7WprsjRoR4RkYBR8IuIBIyCv2WzYl3AUcRrXRC/tamu4xev\ntamuCNExfhGRgNEev4hIwAQq+M1sjpltN7N1R5kfk5vG+6jraq+etWb2hpmNaDJvszd9tZlFfGQ7\nH7VNMLNqb/mrzewnTebF8jv7YZOa1plZvZn19Oa123dmZnlmtsjM1pvZ22Z2Wwttor6e+awrJuuZ\nz9qivp75rCsm61mbOecC8wDGA2cB644y/wvAi4ABY4Fl3vQQ8B4wCEgF3gIKoljXOUAP7/mUxrq8\n15uB7Bh+ZxOA51qYHtPvrFnbS4BXo/GdAX2Bs7zn6cC7zf/uWKxnPuuKyXrms7aor2d+6orVetbW\nR6D2+J13CNADAAAFWklEQVRzi4Fdx2gSk5vGt1aXc+4N59xu72UR4TuZRYWP7+xoYvqdNXMl8GSk\nln0szrmtzrlV3vN9QAnhe083FfX1zE9dsVrPfH5nRxPT76yZqK1nbRWo4PfheG4a73fFjLSvE95b\nbOSAf5jZSjObEaOazvEOEbxoZkO9aXHxnZlZF2Ay8Ncmk6PynZnZQGAksKzZrJiuZ8eoq6mYrGet\n1Baz9ay17yyW69mJ8HPPXYkTZjaR8P+Q5zWZfJ5zbouZ9QIWmtkGb284WlYBA5xzNWb2BeBZYHAU\nl9+aS4Alzrmmvw7a/Tszs26EQ+C7zrm9kfzstvBTV6zWs1Zqi9l65vO/ZUzWsxOlPf5POtpN4/3c\ncL5dmdlwYDYw1Tm3s3G6c26L9+924BnCP32jxjm31zlX4z1/AUgxs2zi4DvzTKfZz+/2/s7MLIVw\nUPzJOfd0C01isp75qCtm61lrtcVqPfPznXmivp61SaxPMkT7AQzk6CcqL+KTJ92We9OTgTIgn49P\nIA2NYl0DCN/P+Jxm07sC6U2evwFMjvJ31oePrwcZDXzgfX8x/c68+RmEzwN0jdZ35v3tjwO/OUab\nqK9nPuuKyXrms7aor2d+6orVetbWR6AO9ZjZk4R7B2SbWQXw70AKxPam8T7q+gmQBfzOzADqXHhQ\nqN7AM960ZODPzrmXIlWXz9q+DNxsZnXAR8B0F17bY/2dAVwG/N05t7/JW9v7OzsXuBZYa2arvWn/\nRjhUY7me+akrVuuZn9pisZ75qQtis561ia7cFREJGB3jFxEJGAW/iEjAKPhFRAJGwS8iEjAKfhGR\ngFHwS4fhjYaY3cbPKDSz+0/wvf80s0/de9Wb/oF5ffu8ac+aWU1bahU5UYHqxy/SGudcMdAeQ+ju\nIdwv/HUzyyQ88qNITGiPXxKKmQ00sw1m9iczKzGzv3gDZDX6jpmt8sZBP83Mksxso5nleO9P8sZt\nzzGzr3hjqL9lZou9+RPM7DnveTcz+733WWvM7Eve9IfMrNgbo/2nPkufS/iyfoDLgSOX/3vLXGxm\nz1t4XPmZZpbkzZvs/T1vmdkrbfryRDwKfklEQ4DfOedOB/YC32oyb4dz7izgIeB251wD8ARwtTf/\nQuAt51wV4StVP++cGwFc2sJy7gKqnXPDnHPDgVe96f/Xu6J1OPAZb3yb1rwCjDezEOENwLxm80cD\n3wEKgJOBy72N1SPAl7wav+JjOSKtUvBLIip3zi3xnj/BJ0eRbNyTXkl4LB+AOcB13vOvAb/3ni8B\nHjOzbxK+3L+5C4EHG1+4j8eqv8LMVgFvAkMJh3Vr6oHXCYd+Z+fc5mbzl7vwmPL1hAf7Oo/wOD6L\nnXObvOWfyH0RRD5FwS+JqPk4I01fH/L+rcc7h+WcKwcqzewCwnvWL3rTbwJ+THh0x5VmltXags0s\nH7gd+Kz3K+B5IM1n3XOB+4H5x/k3iUSUgl8S0QAzG+c9v4rwnnRrZhP+dfCUt1eNmZ3snFvmnPsJ\nUMUnh/cFWAh8u/GFmfUAugP7gWoz6034FoV+vQb8Fy3fpWm0meV7x/aneX9TEeHDQ/ne8nsex7JE\njkrBL4noHeDbZlYC9CB8PL81C4BufHyYB+Be78TtOsLD5r7V7D13Az0aTwADE51zbxE+xLMB+DPh\nw0W+uLD/cc7taGH2CuABwrf32wQ8452HmAE87S2/+XkBkROi0TkloXi3wHvOOXfGcb6vEPi1c+78\n9qirLcxsAuET0RfHuhYJBvXjlw7PzO4Ebubjnj0igaY9fhGRgNExfhGRgFHwi4gEjIJfRCRgFPwi\nIgGj4BcRCRgFv4hIwPx/z2oyKtD9cfsAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7faecdb68668>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "cl_dict = {'z':config['cluster_z'], 'ra':0.0, 'dec': 0.0}\n",
     "saa_ideal = ShearAzimuthalAverager(cl_dict,ideal_data.catalog)\n",
@@ -130,15 +297,27 @@
     "saa_ideal.make_shear_profile()\n",
     "saa_noisy.make_shear_profile()\n",
     "\n",
-    "%matplotlib inline\n",
     "saa_ideal.plot_profile()\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX4AAAEKCAYAAAAVaT4rAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xl8FfW9//HXJxsJCSQhCRBIQsKiyA5GEBW3agUscqsV\nsS7VXou4VO3varW91/Z6f+1Pb721ilIB13LVgm21RQWprajsEpB90bAmyBKRHQIkfH9/nCHGGMgB\nTs6SeT8fj/PgnJnvZD7nOL5n5jubOecQERH/iIt0ASIiEl4KfhERn1Hwi4j4jIJfRMRnFPwiIj6j\n4BcR8RkFv4iIzyj4RUR8RsEvIuIzCZEuoD7Z2dmusLAw0mWIiMSMhQsXfuGcywmmbVQGf2FhISUl\nJZEuQ0QkZpjZxmDbqqtHRMRnFPwiIj6j4BcR8Zmo7OMXEWkMR44coby8nMrKykiXcsqSk5PJy8sj\nMTHxlP+Ggl9EfKO8vJwWLVpQWFiImUW6nJPmnGPHjh2Ul5dTVFR0yn9HXT0i4huVlZVkZWXFZOgD\nmBlZWVmnvcei4BcRX4nV0D8mFPUr+EVETuC68XO5bvzcSJcRUk0q+JvifyARkVBrUsEvIiINU/CL\niITZqlWruPDCC+nVqxePP/44nTt3Duv8dTqniPjSI2+tYOXnexpst3JLoE0w3cjd2rXkl8O6n7BN\nVVUVN9xwAy+88AJ9+/bljjvuoEePHgDs3LmTzMzMIKo/PdriFxEJozfeeIPevXvTt29fALp160bv\n3r0B+MlPfhKWGrTFLyK+1NCW+THHtvQn3z4wJPNdunQpffr0qfm8fPlyBg8ezLvvvsvq1at5/PHH\neeCBB0Iyr+PRFr+ISBhlZWXx6aefArB48WJeeeUVevfuTXZ2NjfeeGOjhz4o+EVEwuqmm26ipKSE\nnj178sILL1BYWEjHjh1ZunRpTZdPY1Pwi4iEUXJyMvPnz2fZsmUUFBTw3e9+F4Ds7Gyef/55Vq1a\n1eg1qI9fROQEQtW3f8zvfvc7Jk2aRGJiIueffz5PPPEEAFdddRVXXXVVSOd1PAp+EZEwevjhh3n4\n4YcjWoO6ekREfEbBLyLiMwp+ERGfUfCLiPiMgl9ExGcU/CIiJ/LSlYFXE6LgFxHxGQW/iIjPKPhF\nRMIsJh7EYmaDgaeAeOB559xjdcabN34ocAC4xTm3yBu3AdgLVANVzrnikFUvInKqpj0EW5c13G7r\n0sC/wfTzt+0JQx47YZMTPYglXBoMfjOLB8YClwPlwAIzm+KcW1mr2RCgi/caADzr/XvMJc65L0JW\ntYhIjKrvQSytW7euGb97927S09O/8T6Ugtni7w+UOufWAZjZJGA4UDv4hwMTnXMOmGdmGWaW65zb\nEvKKT6D6qCM+zsI5SxGJVQ1smdc4tqV/6zshme3xHsRyzP33388999zDtm3bmDFjBr/+9a9DMt/a\nggn+9kBZrc/lfH1r/nht2gNbAAf8w8yqgfHOuQmnXu7xHThcxYrP95CeksjhqqMkJejwhYhEn/oe\nxPLggw/WjH/mmWcYMWJEzW2aG0M40vEC51wfAt1Bd5nZhfU1MrNRZlZiZiUVFRUnPZM4M1omJ7B1\nTyXXjp9L2ZcHTrNsEZHQO96DWI75+OOPycvLo6qqqmYFEWrBBP9mIL/W5zxvWFBtnHPH/t0OvEmg\n6+gbnHMTnHPFzrninJyc4KqvJTkxnsLsVLq0TmNdxT6GjpnJu8vD2tMkItKg4z2I5Zj58+fz9NNP\nM27cOKZPn94oNQQT/AuALmZWZGZJwEhgSp02U4CbLeBcYLdzbouZpZpZCwAzSwW+DSwPYf3f0Co1\niXd+PIiO2amMfmURv/zbcg5VVTfmLEWkKbv1nZD170PgQSzdu3enT58+bNiw4Rv35r///vuJi4sj\nJSWFe+65J2Tzra3BPn7nXJWZ3Q1MJ3A654vOuRVmNtobPw6YSuBUzlICp3Pe6k3eBngzcLYnCcBr\nzrl3Q/4t6ijIas6fRp/HY9NW8+Ls9SzctJNnru9HYXZqY89aROSEouFBLEGdx++cm0og3GsPG1fr\nvQPuqme6dUB4nh5cR1JCHL8Y1o2BnbK4/09L+M7Ts3j06p4M690uEuWIiESNJn/qy+Xd2vDOPRdw\nRps0fvzHT/j5m8uoPKKuHxHxryYf/AB5mc2ZfPtAbr+oI6/N38S/jJ3N2op9kS5LRCIg0EERu0JR\nvy+CHyAxPo6fDTmLl245h217Khn29Cze/KQ8LPO+bvxcrhs/NyzzEpHjS05OZseOHTEb/s45duzY\nQXJy8mn9naD6+JuSS7q2Zuq9g7j3j4v5yeQlzF27g0eu6kFKUnykSxORRpaXl0d5eTmncq1QtEhO\nTiYvL++0/obvgh8gNz2F1340gCf/8RljPyjlk027GHtDP85o0yLSpYlII0pMTKSoqCjSZUScb7p6\n6kqIj+P+K85k4g/7s/PAYa56Zhavl5TF7C6giEiwfBv8xwzqksPUewbRNz+Tn/55Kf/2+hL2H6qK\ndFkiIo3G98EP0LplMq/cNoD7LuvCm4s3M+yZWazasifSZYmINAoFvyc+zrjvsjN49bYB7K2sYvjY\n2bw2f5O6fkSkyVHw13Fep2ym3TuIAUWt+Pmby7hn0mL2Vh6JdFkiIiGj4K9Hdloz/nBrfx644kze\nWfo5w56exfLNuyNdlohISCj4jyMuzrjrks5MGjWQyiNHufr3c/jDnA3q+hGRmKfgb0D/olZMvXcQ\n53fO4pdTVnDnq4vYfVBdPyISuxT8QWiVmsQLPziHnw/tynsrt3HlmJksLtsV6bJERE6Jgj9IcXHG\nqAs7Mfn2gTgH146bw/Mz16nrR0RijoL/JJ3dIZN37rmAi89sza/eWcWPJi5k14HDkS5LRCRoCv5T\nkNE8iQk3nc0vvtONDz/dztCnZrJw45eRLktEJCgK/lNkZvzwgiL+PPo84uONEePnMe7DtRw9qq4f\nEYluTerunJNvHxj2efbOz+Cdewbx0F+W8ti01cxbt4PfXtubrLRmYa9FRCQY2uIPgZbJiYz9fj/+\n7/DuzCndwdAxM5m/bkekyxIRqZeCP0TMjJsGFvLGneeRkhjP9c/N45n3P1PXj4hEnSbV1RMNerRP\n5+17BvHzN5bxP3//lPnrv+RI9VES47WOFZHooOBvBGnNEnhqZB8GdsriP6es4KhzdMpJi3RZIiKA\nunoajZlxff8C/nb3+cTHGau37uXRaas4XHU00qWJiM8p+BtZ17Yt6dEundYtmjH+w3Vc8+wc1lXs\ni3RZIuJjCv4wiI8zirJTGXfj2ZTtPMB3np7F6wv0fF8RiYyggt/MBpvZGjMrNbOH6hlvZjbGG7/U\nzPrVGR9vZp+Y2duhKjwWDe7Rlmn3DqJXXjo//ctS7v7jJ+w+oDt9ikh4NRj8ZhYPjAWGAN2A682s\nW51mQ4Au3msU8Gyd8fcCq0672iYgNz2FV287l58OPpPpy7cy5KmP+Hi9bvcgIuETzBZ/f6DUObfO\nOXcYmAQMr9NmODDRBcwDMswsF8DM8oArgedDWHdMi48z7ry4M3++4zwSE+IYOWEuT/x9DVXVOvAr\nIo0vmOBvD5TV+lzuDQu2zZPATwGlWh19vNs9fLdvHmPeL2XE+LmUfXkg0mWJSBPXqAd3zew7wHbn\n3MIg2o4ysxIzK6moqGjMsqJKWrMEfjuiN2Ou78tn2/cx5KmZ/G3x5kaf73Xj53Ld+LmNPh8RiT7B\nBP9mIL/W5zxvWDBtzgeuMrMNBLqILjWzV+qbiXNugnOu2DlXnJOTE2T5TcdVvdsx9Z5BdG3bgnsn\nLeYnkxezt1IHfkUk9IIJ/gVAFzMrMrMkYCQwpU6bKcDN3tk95wK7nXNbnHM/c87lOecKvened87d\nGMov0JTkt2rOpFHnct9lXfjb4s0MHTOTRZt2RrosEWliGgx+51wVcDcwncCZOa8751aY2WgzG+01\nmwqsA0qB54A7G6neJi8hPo77LjuD128fyNGjcO24uTz9z8+o1s3eRCREgrpXj3NuKoFwrz1sXK33\nDrirgb/xAfDBSVfoU8WFrZh67yD+46/L+e17nzKz9At+d10f2mekRLo0EYlxunI3iqWnJDJmZB9+\ne21vVmzezZAnP2Lqsi2RLktEYpyCP8qZGdecncc79wyiKDuVO19dxIN/Xsr+Q1WRLk1EYpSCP0YU\nZqfy5zvO465LOvH6wjKGPT2LZeW7I12WiMQgBX8MSYyP44EruvLabedy4HA1Vz87m/F6wLuInCQF\nfwwa2CmLd+8bxLe6tuHRaau56cX5bNtTGemyRCRGKPhjVEbzJJ69sR+PXt2TRRt3MfjJj3hv5bZI\nlyUiMUDBH8OOPeXrrR9fQG56Cj+aWMLDf11O5ZHqSJcmIlFMwd8EdG6dxpt3ncePBhXxv/M2Muzp\nWazasifSZYlIlFLwNxHNEuL59yu7MfGH/dl54AjDx87mpdnr9ZQvEfkGBX8YTL59IJNvHxiWeV14\nRg7v3jeICzpn88hbK7n15QV8se9QWOYtIrFBwd8EZac144UfFPNfw7szZ+0OBj/5ER+s2R7pskQk\nSij4mygz4+aBhUy5+3yyUptxy0sL+K+3VnKoSgd+RfxOwd/EdW3bkr/dfT4/GNiBF2ev51/GzuGz\nbXsjXZaIRJCC3weSE+N5ZHgPXvhBMdv2VDLsmVls21OpA78iPqXg95FvndWGd+8dxDmFrdiw4wCf\nbtvH6q3RddqnHgkp0vgU/D7TumUyf7i1PwWtUthTeYTBT87kRxNLWFK2K9KliUiYBPUgFmla4uKM\n3PQUctKacUGXHF6es4HhK2czqEs2d1/SmQEdsyJdoog0Im3x+1hCfBw/ufwMZj90KQ8N6cqqLXu4\nbsI8rh03hw/WbNcxAJEmSsEvpDVLYPRFnZj14KX857BulO88yC0vLeCqZ2bz7vItuu2zSBOj4Jca\nyYnx3HJ+ER8+cAn/fU1P9lYeYfQri7jiyY/46yebqao+GukSRSQEFPzyDUkJcVx3TgH/+D8X8dTI\nPpjBfZMXc+lvP+SPH2/SRWAiMU7BL8eVEB/H8D7teffeCxl/09lkNE/kZ28s46LffMCLs9Zz8LBW\nACKxSMEvDYqLM67o3pa/3XU+E3/Yn4Ks5vzX2yu54L/f5/cflLK38kikSxSRk6DTOSVoZsaFZ+Rw\n4Rk5fLz+S56ZUcpv3l3DuA/Wcst5hdx6fhGZqUmRLlNEGqDgl1PSv6gVE4v6s7R8F2NnlDLm/VKe\nn7WeG8/twG0XFNG6ZXKkSxSR41Dwy2nplZfB+JuK+XTbXn4/o5TnZ67j5TkbuK44n9sv6kheZvNI\nlygidQTVx29mg81sjZmVmtlD9Yw3MxvjjV9qZv284clm9rGZLTGzFWb2SKi/gESHM9q04MmRfXn/\n3y7m6r7tmbRgExc//gH3/2kJ6yr2Rbo8EamlweA3s3hgLDAE6AZcb2bd6jQbAnTxXqOAZ73hh4BL\nnXO9gT7AYDM7N0S1SxQqzE7lsWt68eEDl3DjuR14a8nnfOuJD7n7tUV6DrBIlAhmi78/UOqcW+ec\nOwxMAobXaTMcmOgC5gEZZpbrfT62uZfovXQZqA+0y0jhP6/qzqwHL+X2CzvxwZoKhjw1k9v+sIBP\nNu2MdHkivhZM8LcHymp9LveGBdXGzOLNbDGwHXjPOTe/vpmY2SgzKzGzkoqKimDrlyiX06IZDw3p\nyuwHL+Unl51BycadfPf3c7jh+XnMXbtD9wMSiYBGP4/fOVftnOsD5AH9zazHcdpNcM4VO+eKc3Jy\nGrssCbP05once1kXZj14KT8f2pU1W/dx/XPz+N64ucxYHf03hNNzAqQpCeasns1Afq3Ped6wk2rj\nnNtlZjOAwcDyky9VmoK0ZgmMurATNw8s5PWSMsZ/uI5bX15A93YtueuSzjjnMLNIlynSpAWzxb8A\n6GJmRWaWBIwEptRpMwW42Tu751xgt3Nui5nlmFkGgJmlAJcDq0NYv8So5MR4bh5YyIz7L+Y33+vF\ngcPV3PnqIpZu3s32vYfYf6gq0iWKNFkNbvE756rM7G5gOhAPvOicW2Fmo73x44CpwFCgFDgA3OpN\nngv8wTszKA543Tn3dui/hsSqpIQ4RhTnc02/PKYu28KDf1nK+i/20//X/+A7vdox4pw8+hVkai9A\nJISCuoDLOTeVQLjXHjau1nsH3FXPdEuBvqdZo/hAfJwxrHc7/nfuBvYdqqJH+3TeWvo5k0vK6JST\nyojifK7ul0dOi2aRLlUk5unKXZ+afPvASJdQLzOjRXIiv/leb34xrDtTl25hckkZj05bzePT13BJ\n19ZcV5zPxWfmkBCvewyKnAoFv0SttGYJjDgnnxHn5FO6fR9/KinjL4s2897KbeS0aMY1/fK4tjiP\nTjlpkS5VJKYo+CUmdG6dxs+GnsX9V5zJjNXbeb2knOdmrmPch2s5pzCTa4vzubJnLqnNtEiLNET/\nl0hMSYyP49vd2/Lt7m3ZvreSNxZt5vUFZfz0z0t5ZMoK74BwPv0KMnRAWOQ4FPwSs1q3SGb0RZ24\n/cKOLNy4k9dLymoOCHduncaI4jy+21cHhEXqUvBLzDMzigtbUVzY6msHhP/f1NX85l0dEBapS8Ev\nTYoOCIs0TMEvTZYOCIvUT0u8NHn1HhAuaToHhI/dPC5ar82Q6KPgF1/RAWERBb/4VEMHhC/t2poR\nOiAsTZSCX3zvGweEF5bxl4Wb+XutA8IHD1eTkhQf6VJFQkLBL1JL59Zp/GzIWdz/7TP5YE0FkxeU\n8dzMdVQfdaQ1S+Cl2esZ3KMtuekpkS5V5JQp+EXqkRgfx+Xd2nB5tzZs31vJNb+fwxf7DvPIWyt5\n5K2V9CvIYGjPXAb3aEteZvNIlytyUhT8Ig1o3SKZdhkptMtI4dGrezJt+VamLtvCr95Zxa/eWUXv\nvHSG9MxlaI9cCrK0EpDop+AXOQkdc9K465LO3HVJZzbu2M+05VuZtmwLj01bzWPTVtOjfUuG9Mhl\nSI+2dNRFYhKlFPwip6hDViqjL+rE6Is6UfblAaavCOwJPD59DY9PX0PXti0Y2jOXoT3b0rl1i0iX\nGxG6xiA6KfglqsRqQOS3as5tgzpy26COfL7rIO8u38q05Vv43T8+5Yn3PqVL67RAd1DPtpzZpkVM\nXigmTYeCXyTE2mWk8MMLivjhBUVs21NZsyfwzPufMeafn9ExJ5WhPXIZ0rMt3XJbaiUgYafgF2lE\nbVomc/PAQm4eWEjF3kP8fWVgJfDsh2t5ZkYpHbKaM6RHYE+gZ/t0rQQkLBT8ImGS06IZNwzowA0D\nOrBj3yHeW7mNqcu38rx347j2GSkM7dmWIT1z6ZOXQVycVgLSOBT8IhGQldaMkf0LGNm/gF0HDvPe\nym1MW76Vl+ds4LmZ68lNT2Zwj7Zc2TOXfgWZWglISCn4RSIso3kS1xbnc21xPrsPHuGfq7YxddlW\nXp2/iZdmb6B1i2YM6RHYEzinsBXxWgmcMp1lFKDgF4ki6SmJXN0vj6v75bG38gjvr97OtGVbmbSg\njD/M3Uh2WhJXdG/L0J65DChqpRvIySlR8ItEqRbJiQzv057hfdqz/1AVH6ypYOryLbyxaDOvzt9E\nq9Qkrujehl0HjtAyRf8rS/C0tIjEgNRmCVzZK5cre+Vy8HA1H366nanLtjJl8efsP1xNfJxx0wvz\n6ZOfUfPKStMzBaR+QQW/mQ0GngLigeedc4/VGW/e+KHAAeAW59wiM8sHJgJtAAdMcM49FcL6RXwn\nJSmewT1yGdwjl8oj1Vz19Cx2HjxCxd5DjJ1RylEXaJffKoU++Zn0zkunb0EG3dulk5yoW0tLEMFv\nZvHAWOByoBxYYGZTnHMrazUbAnTxXgOAZ71/q4B/81YCLYCFZvZenWlF5BQlJ8aTmZpEZmoSk28f\nyP5DVSzfvJvFZbtYXLaLkg1f8taSzwFIiDPOym351V5BQQZFWak6Y8iHgtni7w+UOufWAZjZJGA4\nUDu8hwMTnXMOmGdmGWaW65zbAmwBcM7tNbNVQPs604pIiKQ2S2BAxywGdMyqGbZtTyWfbNrFkvJd\nLN60izcWlfO/8zYC0DI5gd61uofUReQPwQR/e6Cs1udyAlvzDbVpjxf6AGZWCPQF5tc3EzMbBYwC\nKCgoCKIsEQlGm5aBawIG92gLQPVRR+n2fSwu2+ntGez+RhdR77zASkBdRE1TWA7umlka8BfgPufc\nnvraOOcmABMAiouLXTjqEvGj+DjjzLYtOLNtC647J7CRdeBwFcvKv+oiWrhxJ28vDWy31e4iOrZ3\n0DFbXUSxLJjg3wzk1/qc5w0Lqo2ZJRII/Vedc2+ceqkikdPUL/hpnlR/F9GxFYG6iJqWYIJ/AdDF\nzIoIhPlI4Pt12kwB7vb6/wcAu51zW7yzfV4AVjnnnghh3SLSyNq0TOaK7m25ovtXXURrK/axeNMu\nPvFWCLW7iPIyU2pWAse6iCR44byquMHgd85VmdndwHQCp3O+6JxbYWajvfHjgKkETuUsJXA6563e\n5OcDNwHLzGyxN+znzrmpof0aItLY4uOMM9q04Iw2LRhxTmAH/1gX0ZLywIpgUZ0uoqSEOJonxTN2\nRimdclLplJNGh6xUkhJ0xXEkBdXH7wX11DrDxtV674C76pluFqCOQJEmqr4uou17KvmkbBdLynbx\nyryN7D54hMenr6kZHx9n5Gem0CknjU6t0+iYnUqn1ml0ykmjVWpSJL6G7+jKXREJqda1uogWbtwJ\nwAu3nMP6iv2srdjH2op9rPPezyz9gsNVR2umzWieGFgh5KTSMSet5n1+q+Yk6r5EIaPgF5FGl9Ys\ngZ556fTM+3q/f/VRx+e7DlJasY+12/ex7ov9rN2+j/dXV/B6SXlNu4Q4o0NWczrlpHkrBG8vITuN\n9OaJ4f46MU/BLyIREx9n5LdqTn6r5lxyZuuvjdt98Ajrau0dHNtTmLFmO0eqvzrjOzst6auVgbeX\n0DEnlbzM5rqF9XEo+EUkKqWnJNK3IJO+BZlfG15VfZSynQdZ560M1m7fz7ov9jF9xTa+3P/VdaRJ\nCXEUZaXS0VshdMxJZd+hKl2MhoJfRGJMQnwcRdmpFGWn8q2z2nxt3M79h1n3RWBlENhL2M+arXv5\n+8ptVB/9ai/h8ic+pF9BJmd3yKRfhww6Zqf56oI0Bb+INBmZqUmcndqKszu0+trww1VH2fTlAe54\nZSEHD1eT36o501duZXJJYA8hsHeRwdkFmfTrkEnv/AzSmjXdeGy630xExJOUEEfn1t7poqnw4i3n\n4Jxj3Rf7WbhxJ59s2snCjTv58NMKnIM4gzPbtuTsDhk1ewYFrZoTuCY19in4RcSXzKzmYPCI4sAF\nabsPHqm5EG3Rpp387ZPPeWXeJgCyUpPo1yGzZkXQKy92b16n4BcR8aSnJHLRGTlcdEYOEDjd9LPt\ne1m0cVfNnsF7K7cBgVNMu7drSd+aYwWZtEtPjom9AgW/SIxr6jeQi6T4OKNr25Z0bduS7w8I3Mn0\ny/2Ha7qGFm3ayeQFZbw8ZwMAbVsm08/rHurXIZPu7VrSLCH69goU/CIiJ6FVahLfOqtNzRlFVdVH\nWb11b82KYOHGnUxdthUIHFvo2T6dfgUZgb2Cgkxat0yOZPmAgl9E5LQkxMfRo306Pdqn84PzCoHA\n/YoWbdrJok2BLqI/zN3IczPXA4G7mNacSlqQSdfcFmG/HYWCX0QkxFq3TGZwj1wG98gF4FBVNSs+\n31Nz0Hj++h1M8Z6FnJIYT6+8dMq+PEBacgJHj7pGv6ZAwS8i0siaJcQH+v29q5Cdc3y+u5JFG3fW\nHDTesruShH1GOI4NK/hFRMLMzGifkUL7jBSG9W4HwPeencPhqqNhOStI9zkVEYkC8XFGSlJ4zgBS\n8IuI+Iy6ekSk0egag+ikLX4REZ9R8IuI+IyCX0TEZxT8IiI+o+AXEfEZndUjIr6hs4wCtMUvIuIz\nQQW/mQ02szVmVmpmD9Uz3sxsjDd+qZn1qzXuRTPbbmbLQ1m4iIicmgaD38zigbHAEKAbcL2ZdavT\nbAjQxXuNAp6tNe5lYHAoihURkdMXzBZ/f6DUObfOOXcYmAQMr9NmODDRBcwDMswsF8A59xHwZSiL\nFhGRUxdM8LcHymp9LveGnWwbERGJAlFzcNfMRplZiZmVVFRURLocEZEmK5jTOTcD+bU+53nDTrbN\nCTnnJgATAIqLi93JTCsiEuvCeappMFv8C4AuZlZkZknASGBKnTZTgJu9s3vOBXY757aEuFYREQmB\nBoPfOVcF3A1MB1YBrzvnVpjZaDMb7TWbCqwDSoHngDuPTW9mfwTmAmeaWbmZ/WuIv4OIiJwEcy76\nelWKi4tdSUlJpMsQEYkZZrbQOVccTNuoObgrIiLhoeAXEfEZBb+IiM8o+EVEfEbBLyLiMwp+ERGf\nUfCLiPiMgl9ExGcU/CIiPqPgFxHxGQW/iIjPKPhFRHxGwS8i4jMKfhERn1Hwi4j4jIJfRMRnFPwi\nIj6j4BcR8RkFv4iIzyj4RUR8RsEvIuIzCn4REZ9R8IuI+IyCX0TEZxT8IiI+o+AXEfGZoILfzAab\n2RozKzWzh+oZb2Y2xhu/1Mz6BTutiIiEV4PBb2bxwFhgCNANuN7MutVpNgTo4r1GAc+exLQiIhJG\nwWzx9wdKnXPrnHOHgUnA8DpthgMTXcA8IMPMcoOcVkREwighiDbtgbJan8uBAUG0aR/ktKEz7SHY\nuqzR/ryISKNq2xOGPNbos4mag7tmNsrMSsyspKKiItLliIg0WcFs8W8G8mt9zvOGBdMmMYhpAXDO\nTQAmABQXF7sg6vqmMKwpRURiXTBb/AuALmZWZGZJwEhgSp02U4CbvbN7zgV2O+e2BDmtiIiEUYNb\n/M65KjO7G5gOxAMvOudWmNlob/w4YCowFCgFDgC3nmjaRvkmIiISFHPu1HpVGlNxcbErKSmJdBki\nIjHDzBY654qDaRs1B3dFRCQ8FPwiIj6j4BcR8RkFv4iIzyj4RUR8JirP6jGzCmBjBEvIBr6I4PyP\nJ1rrgugLVpE5AAAGn0lEQVStTXWdnGitC6K3tmipq4NzLieYhlEZ/JFmZiXBnhYVTtFaF0Rvbarr\n5ERrXRC9tUVrXSeirh4REZ9R8IuI+IyCv34TIl3AcURrXRC9tamukxOtdUH01hatdR2X+vhFRHxG\nW/wiIj7jq+A3sxfNbLuZLT/O+Ig8ND6Ium7w6llmZnPMrHetcRu84YvNLOR3tguitovNbLc3/8Vm\n9ota4yL5mz1Qq6blZlZtZq28cY32m5lZvpnNMLOVZrbCzO6tp03Yl7Mg6wr7chZkXZFaxoKpLSLL\n2WlzzvnmBVwI9AOWH2f8UGAaYMC5wHxveDywFugIJAFLgG5hrOs8INN7P+RYXd7nDUB2BH+zi4G3\n6xke0d+sTtthwPvh+M2AXKCf974F8Gnd7x2J5SzIusK+nAVZV6SWsQZri9RydrovX23xO+c+Ar48\nQZOIPDS+obqcc3Occzu9j/MIPMksLIL4zY4nor9ZHdcDfwzVvE/EObfFObfIe78XWEXg2dO1hX05\nC6auSCxnQf5ex9PYy9jJ1ha25ex0+Sr4g3AyD40PduEMtX8lsLV4jAP+YWYLzWxUhGo6z+simGZm\n3b1hUfGbmVlzYDDwl1qDw/KbmVkh0BeYX2dURJezE9RVW9iXswbqiugy1tBvFsnl7FQE88xdiRJm\ndgmB/yEvqDX4AufcZjNrDbxnZqu9reFwWQQUOOf2mdlQ4K9AlzDOvyHDgNnOudp7B43+m5lZGoEQ\nuM85tyeUf/t0BFNXJJazBuqK6DIW5H/LiCxnp0pb/F93vIfGB/PA+UZlZr2A54Hhzrkdx4Y75zZ7\n/24H3iSw+xs2zrk9zrl93vupQKKZZRMFv5lnJHV2vxv7NzOzRAJB8apz7o16mkRkOQuirogsZw3V\nFcllLJjfzBP25ey0RPogQ7hfQCHHP1B5JV8/6PaxNzwBWAcU8dVBpO5hrKuAwPOMz6szPBVoUev9\nHGBwmH+ztnx1PUh/YJP3+0X0N/PGpxM4DpAart/M++4TgSdP0Cbsy1mQdYV9OQuyrogsY8HUFqnl\n7HRfvurqMbM/EjhDINvMyoFfAokQ2YfGB1HXL4As4PdmBlDlAjeFagO86Q1LAF5zzr0bqrqCrO17\nwB1mVgUcBEa6wNIe6d8M4LvA351z+2tN2ti/2fnATcAyM1vsDfs5gVCN5HIWTF2RWM6CqSsiy1iQ\ntUFklrPToit3RUR8Rn38IiI+o+AXEfEZBb+IiM8o+EVEfEbBLyLiMwp+aTK8uyFmn+bfKDazMac4\n7Qdm9o1nr3rDN5l3bp837K9mtu90ahU5Vb46j1+kIc65EqAxbqG7i8B54bPMLIPAnR9FIkJb/BJT\nzKzQzFab2atmtsrM/uzdIOuYH5vZIu8+6F3NLM7MPjOzHG/6OO/e7Tlmdq13D/UlZvaRN/5iM3vb\ne59mZi95f2upmV3jDX/WzEq8e7Q/EmTpkwhc1g9wNVBz+b83z4/M7B0L3Ft+nJnFeeMGe99niZn9\n87R+PBGPgl9i0ZnA751zZwF7gDtrjfvCOdcPeBa43zl3FHgFuMEbfxmwxDlXQeBK1Succ72Bq+qZ\nz8PAbudcT+dcL+B9b/i/e1e09gIu8u5v05B/AheaWTyBFcDkOuP7Az8GugGdgKu9ldVzwDVejdcG\nMR+RBin4JRaVOedme+9f4et3kTy2Jb2QwL18AF4Ebvbe/xB4yXs/G3jZzH5E4JL/ui4Dxh774L66\nV/0IM1sEfAJ0JxDWDakGZhEI/RTn3IY64z92gfvKVxO42dcFBO7j85Fzbr03/1N5LoLINyj4JRbV\nvc9I7c+HvH+r8Y5hOefKgG1mdimBLetp3vDRwH8QuMPjQjPLamjGZlYE3A98y9sLeAdIDrLuScAY\n4PWT/E4iIaXgl1hUYGYDvfffJ7Al3ZDnCewd/MnbqsbMOjnn5jvnfgFU8PVb/AK8B9x17IOZZQIt\ngf3AbjNrQ+ARhcGaCTxK/U9p6m9mRV7f/nXed5pHoHuoyJt/q5OYl8hxKfglFq0B7jKzVUAmgf78\nhkwB0viqmwfgce/A7XICt81dUmeaXwGZxw4AA5c455YQ6OJZDbxGoLsoKC7gf5xzX9QzegHwDIHH\n+60H3vSOQ4wC3vDmX/e4gMgp0d05JaZ4j8B72znX4ySnKwZ+55wb1Bh1nQ4zu5jAgejvRLoW8Qed\nxy9Nnpk9BNzBV2f2iPiatvhFRHxGffwiIj6j4BcR8RkFv4iIzyj4RUR8RsEvIuIzCn4REZ/5/xHH\n7lXOsgwzAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7faecd83bf60>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "saa_noisy.plot_profile()"
    ]
@@ -154,8 +333,9 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -169,7 +349,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/examples/fake_data_demo.ipynb
+++ b/examples/fake_data_demo.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import sys \n",
@@ -44,14 +46,17 @@
     "config['ngals'] = 10000\n",
     "config['mdef'] = '200c'\n",
     "\n",
-    "my_data = mock.MockData(config=config)"
+    "ideal_data = mock.MockData(config=config)\n",
+    "noisy_data = mock.MockData(config=config)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Generate the mock catalog from the configuration"
+    "### Generate the mock catalog from the configuration\n",
+    "* Ideal data\n",
+    "* Noisy data, including shape noise and redshift error"
    ]
   },
   {
@@ -60,8 +65,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_data.generate()\n",
-    "my_data.catalog"
+    "ideal_data.generate()\n",
+    "noisy_data.generate(is_shapenoise=True, is_zerr=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ideal_data.catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#### Noisy data table has"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "noisy_data.catalog"
    ]
   },
   {
@@ -74,7 +108,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from clmm import ShearAzimuthalAverager"
@@ -87,19 +123,33 @@
    "outputs": [],
    "source": [
     "cl_dict = {'z':config['cluster_z'], 'ra':0.0, 'dec': 0.0}\n",
-    "saa = ShearAzimuthalAverager(cl_dict,my_data.catalog)\n",
-    "saa.compute_shear()\n",
-    "shear_prof = saa.make_shear_profile()\n",
-    "saa.plot_profile()\n",
+    "saa_ideal = ShearAzimuthalAverager(cl_dict,ideal_data.catalog)\n",
+    "saa_noisy = ShearAzimuthalAverager(cl_dict,noisy_data.catalog)\n",
+    "saa_ideal.compute_shear()\n",
+    "saa_noisy.compute_shear()\n",
+    "saa_ideal.make_shear_profile()\n",
+    "saa_noisy.make_shear_profile()\n",
+    "saa_ideal.plot_profile()\n",
+    "saa_noisy.plot_profile()\n",
+    "\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "desc-clmassmod",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "desc-clmassmod"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -111,7 +161,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/examples/fake_data_demo.ipynb
+++ b/examples/fake_data_demo.ipynb
@@ -81,14 +81,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": true
    },
-   "outputs": [],
    "source": [
-    "#### Noisy data table has"
+    "#### If redshift error is requested, the table also includes a gaussian pdz and corresponding bins"
    ]
   },
   {

--- a/tests/test_shear_azimuthal_averager.py
+++ b/tests/test_shear_azimuthal_averager.py
@@ -2,7 +2,7 @@
 import numpy as np
 from astropy.table import Table
 # model from Dallas group
-import colossus.cosmology.cosmology as Cosmology # used for distances
+import colossus.cosmology.cosmology as Cosmology # used for distances, will need to change this
 
 from clmm import models, summarizer
 import clmm.models.CLMM_densityModels_beforeConvertFromPerH as dm


### PR DESCRIPTION
MockData class to generate mock background galaxy catalogs including:
* the ideal case: no redshift error, no shape noise
* the non-ideal case: optionally include redshift error and/or shape noise. If a redshift error is requested, the catalog also includes the associated Gaussian pdz.

At the moment, all background galaxies have the same redshift (with some error if requested).

This comes with a demo python notebook in the "example" directory.

Issue/15/fake_data could be closed for the time being.