### PR TITLE
Issue/73/Fix inconcistency of  GalaxyClusters.find_data behaviour

### DIFF
--- a/clmm/galaxycluster.py
+++ b/clmm/galaxycluster.py
@@ -51,15 +51,14 @@ class GalaxyCluster():
 
         Returns
         -------
-        found: list, clmm.GCData objects or boolean
+        found: list
             List of clmm.GCData object data with required creator and set of specs
-            if no objects are found, returns False
+            if no objects are found, returns empty list
         '''
+        found = []
         if lookup_creator in self.data:
             found = find_in_datalist(lookup_specs, self.data[lookup_creator], exact=exact)
-        else:
-            found = False
-        return(found)
+        return found
 
     def add_data(self, incoming_data, force=False):
         '''

--- a/tests/test_galaxycluster.py
+++ b/tests/test_galaxycluster.py
@@ -40,6 +40,8 @@ def test_find_data():
 
     gc = GalaxyCluster(test_data)
 
+    tst.assert_equal([], gc.find_data(test_creator_diff, test_dict))
+
     tst.assert_equal([test_data], gc.find_data(test_creator, test_dict))
     tst.assert_equal([test_data], gc.find_data(test_creator, test_dict_sub))
     tst.assert_equal([], gc.find_data(test_creator, test_dict_diff))


### PR DESCRIPTION
make GalaxyClusters.find_data always return [] when no cluster found (Issue #73)