### PR TITLE
Issue/82/doces arent working

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-# CLMM [![Documentation Status](https://readthedocs.org/projects/clmm/badge/?version=master)](https://clmm.readthedocs.io/en/master/?badge=master)
+# CLMM [![Documentation Status](https://readthedocs.org/projects/clmm/badge/?version=master)](https://clmm.readthedocs.io/en/master/?badge=master) [![Build Status](https://travis-ci.org/LSSTDESC/CLMM.svg?branch=master)](https://travis-ci.org/LSSTDESC/CLMM)
 
 A new and improved cluster mass modeling code descended from [clmassmod](https://github.com/LSSTDESC/clmassmod)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,9 @@
+API Documentation
+=================
+
+Information on specific functions, classes, and methods.
+
+.. toctree::
+   :glob:
+
+   api/*

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,9 +1,0 @@
-API Documentation
-=================
-
-Information on specific functions, classes, and methods.
-
-.. toctree::
-   :glob:
-
-   api/*

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ import sys
 #sys.path.insert(0, os.path.abspath('.'))
 #sys.path.insert(0, os.path.abspath('../'))
 sys.path.insert(0, os.path.abspath('../clmm'))
+sys.path.insert(0, os.path.abspath('..')) 
 
 
 # -- General configuration ------------------------------------------------
@@ -73,7 +74,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'api/clmm.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
@@ -181,7 +182,8 @@ def run_apidoc(_):
     cur_dir = os.path.normpath(os.path.dirname(__file__))
     output_path = os.path.join(cur_dir, 'api')
     modules = os.path.normpath(os.path.join(cur_dir, "../clmm"))
-    main(['-e', '-f', '-M', '-o', output_path, modules])
+    paramlist = ['--no-headings', '--no-toc', '-f', '-M', '-o', output_path, modules]
+    main(paramlist)
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,10 +182,49 @@ def run_apidoc(_):
     cur_dir = os.path.normpath(os.path.dirname(__file__))
     output_path = os.path.join(cur_dir, 'api')
     modules = os.path.normpath(os.path.join(cur_dir, "../clmm"))
-    paramlist = ['--no-headings', '--no-toc', '-f', '-M', '-o', output_path, modules]
+    paramlist = ['--no-headings', '--separate', '--no-toc', '-f', '-M', '-o', output_path, modules]
     main(paramlist)
 
 
 
 def setup(app):
     app.connect('builder-inited', run_apidoc)
+
+
+
+# -- Set up the API page -------------------------------------------------
+apiheader = \
+"""API Documentation
+=================
+
+Information on specific functions, classes, and methods.
+
+.. toctree::
+   :glob:
+
+"""
+
+# Only find pages that are top level
+def make_final_doclist(flist, append, extend):
+    outlist = [append + fname.split('.')[0] + extend
+        for fname in flist
+        if (not fname[0] == '_') and ((fname.split('.')[-1] == 'py') or len(fname.split('.')) < 2)]
+    return outlist
+
+# Changeable variables
+docappend = 'api/clmm.'
+docextension = '.rst'
+
+# Load file list
+baseflist = os.listdir('../clmm')
+finalflist = make_final_doclist(baseflist, docappend, docextension)
+finalflist.sort(key = lambda x: x.split('.')[1])
+
+apitoc = """"""
+for finalf in finalflist:
+    apitoc += """   {}\n""".format(finalf)
+
+with open('api.rst', 'w') as apifile:
+    apifile.write(apiheader+apitoc)
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,4 +13,4 @@ CLMM
    :maxdepth: 1
    :caption: Reference
 
-   CLMM Reference/API<api/modules>
+   api

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ astropy
 matplotlib
 numpy
 scipy
+colossus


### PR DESCRIPTION
The hosted documentation was not compiling because `colossus` needed to be included in the requirements file. While I was at it, I also cleaned up the presentation of the api page.

This PR resolves Issue #82. You can view the current master branch docs on readthedocs (default page) and this branch by changing the branch in the bottom left-hand corner of readthedocs.