### PR TITLE
Fixing issue #104, sphinx broken in master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-docs/_build/*
 build
 dist
 *~
@@ -6,5 +5,9 @@ __pycache__
 .cache*
 *.pyc
 *.egg*
-docs/api/
 .ipynb*
+
+# Documentation Files
+docs/api/
+docs/_build/*
+docs/api.rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   #- pip install nbconvert
 
   # Finally get set up to build the docs:
-  - pip install sphinx
+  - pip install sphinx==2.1.2
   - pip install sphinx_rtd_theme
 
   # Other dependencies here:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,11 @@ install:
   - pip install sphinx==2.1.2
   - pip install sphinx_rtd_theme
 
-  # Other dependencies here:
-  - pip install pylint
+  # Other dependencies here: # This is done through requirements.txt
   #- pip install pyccl
-  - pip install astropy
-  - pip install scipy
-  - pip install colossus==1.2.5
+  #- pip install astropy
+  #- pip install scipy
+  #- pip install colossus==1.2.5
   #- pip install matplotlib
 
 script:
@@ -41,6 +40,3 @@ script:
   # Run the docs:
   - sphinx-quickstart -a "travis" -p clmm -v 0.0.1 --ext-autodoc -q
   - make -C docs/ html
-
-  # Run pylint - Not for the minimal working example
-  #- find clmm/ -iname "*.py" | xargs pylint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,12 @@ If you do have edit privledges to CLMM, it may be easier to simply clone the bas
 
 ## Making and submitting changes
 Once you've created a local copy of CLMM on your machine, you can begin making changes to the code and submitting them for review. To do this, follow the following steps from within your local copy of CLMM (forked or base).
+
 1. Checkout a new branch to contain your code changes independently from the master repository. [Branches](https://help.github.com/articles/about-branches/) allow you to isolate temporary development work without permanently affecting code in the repository. 
     ```bash
     git checkout -b branchname
     ```
-    Your `branchname` should be descriptive of your code changes. If you are addressing a particular Issue #`xx`, then `branchname` should be formatted as `issue/xx/summary` where `summary` is a description of your changes.
+    Your `branchname` should be descriptive of your code changes. If you are addressing a particular issue #`xx`, then `branchname` should be formatted as `issue/xx/summary` where `summary` is a description of your changes.
 2. Make your changes in the files stored in your local directory.
 3. Commit and push your changes to the `branchname` branch of the remote repository. 
     ```bash
@@ -32,6 +33,8 @@ Once you've created a local copy of CLMM on your machine, you can begin making c
     git push origin branchname
     ```
 4. You can continue to edit your code and push changes to the `branchname` remote branch. Once you are satisfied with your changes, you can submit a [pull request](https://help.github.com/articles/about-pull-requests/) to request that the changes you made in `branchname` be merged into the master repository. Navigate to the [CLMM pulls page](https://github.com/LSSTDESC/CLMM/pulls) and click 'New pull request.' Select `branchname`, fill out a name and description for the pull request, and submit for approval by CLMM admins. Once the pull request is approved, it will be merged into the CLMM master branch.
+
+NOTE: Code is not complete without unit tests and documentation. Please ensure that unit tests (both new and old) all pass and that docs run successfully. To run all of the unit tests, run `py.test` in the root package directory. To test the docs, in the root package directory, run `make -C docs/ clean` to delete any existing documents and then `make -C docs/ html` to rebuild the documentation. If you do not first run `clean`, you may compile locally but fail online.
 
 ## Additional resources
 Here's a list of additional resources which you may find helpful in navigating git for the first time.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,6 +7,7 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = CLMM
 SOURCEDIR     = .
 BUILDDIR      = _build
+RM			  = rm -rf
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -17,6 +18,10 @@ help:
 .PHONY: html
 html: 
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(0) -W
+
+.PHONY: clean
+clean:
+	@$(RM) _build/* api/ api.rst 	
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,7 +182,6 @@ def run_apidoc(_):
     cur_dir = os.path.normpath(os.path.dirname(__file__))
     output_path = os.path.join(cur_dir, 'api')
     modules = os.path.normpath(os.path.join(cur_dir, "../clmm"))
-    #paramlist = ['--no-headings', '--separate', '--no-toc', '-f', '-M', '-o', output_path, modules]
     paramlist = ['--separate', '--no-toc', '-f', '-M', '-o', output_path, modules]
     apidoc_main(paramlist)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,12 +178,12 @@ napoleon_use_ivar = True
 
 # -- Options for Autodoc--------------------------------------------------
 def run_apidoc(_):
-    from sphinx.apidoc import main
+    from sphinx.apidoc import main as apidoc_main
     cur_dir = os.path.normpath(os.path.dirname(__file__))
     output_path = os.path.join(cur_dir, 'api')
     modules = os.path.normpath(os.path.join(cur_dir, "../clmm"))
     paramlist = ['--no-headings', '--separate', '--no-toc', '-f', '-M', '-o', output_path, modules]
-    main(paramlist)
+    apidoc_main(paramlist)
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,11 +178,12 @@ napoleon_use_ivar = True
 
 # -- Options for Autodoc--------------------------------------------------
 def run_apidoc(_):
-    from sphinx.apidoc import main as apidoc_main
+    from sphinx.ext.apidoc import main as apidoc_main
     cur_dir = os.path.normpath(os.path.dirname(__file__))
     output_path = os.path.join(cur_dir, 'api')
     modules = os.path.normpath(os.path.join(cur_dir, "../clmm"))
-    paramlist = ['--no-headings', '--separate', '--no-toc', '-f', '-M', '-o', output_path, modules]
+    #paramlist = ['--no-headings', '--separate', '--no-toc', '-f', '-M', '-o', output_path, modules]
+    paramlist = ['--separate', '--no-toc', '-f', '-M', '-o', output_path, modules]
     apidoc_main(paramlist)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 astropy>=3
 matplotlib
-numpy>=1.17
+numpy>=1.16
 scipy>=1.3
 colossus==1.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-astropy
+astropy>=3
 matplotlib
-numpy
-scipy
-colossus
+numpy>=1.17
+scipy>=1.3
+colossus==1.2.5


### PR DESCRIPTION
In late April, Sphinx deprecated versions 1.X and moved to 2.X. As we are not specifying a version of sphinx to use, Travis used the most recent version (v2.1.2) which then crashed and caused Travis to fail.

While Travis was failing, the docs looked good on readthedocs (rtd). This was because rtd was set to use the CPython 2.X interpreter. Since sphinx v2.X no longer has Python 2.X support, rtd defaulted to sphinx 1.X and compiled fine.

I have updated our sphinx files to be compatible with sphinx 2.X. I have also added the version number for sphinx in the travis config file to avoid this problem in the future.

Note: Sphinx 2.X generates a warning for the rtd template. A feature in this template will be deprecated in the future (shouldn't be an issue since we now specify v2.1.2 for sphinx). The developers of this template have fixed this and it will be included in the future v0.44. The most recent public release is v0.43 so we will have to live with this warning for a bit.

See the docs here: https://clmm.readthedocs.io/en/issue-104-sphinx-broken-in-master/api.html