### PR TITLE
Continuous integration now works again!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ install:
   - sudo apt-get update
 
   # Install an updated gcc
-  - sudo apt-get install build-essential
-  # - sudo add-apt-repository ppa:jonathonf/gcc-9.0
-  # - sudo apt-get install gcc-9
+  # - sudo apt-get install build-essential
+  - sudo add-apt-repository ppa:jonathonf/gcc-9.0 -y
+  - sudo apt-get install gcc-9 -y
   - CC="gcc-9"
 
   # Install GSL

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ install:
   # Install an updated gcc
   # - sudo apt-get install build-essential
   # - sudo add-apt-repository ppa:jonathonf/gcc-9.0 -y
-  - sudo apt-get install gcc-6 -y
-  - CC="gcc-6"
+  - sudo apt-get install gcc-7 -y
+  - CC="gcc-7"
 
   # Install GSL
   - sudo apt-get install libgsl0-dev -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,29 +6,10 @@ python:
 - "3.6"
 
 install:
-  # - sudo apt-get update
-
-  # Install an updated gcc
-  # - sudo apt-get install build-essential software-properties-common -y
-  # - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  # - sudo apt-get update
-  # - sudo apt-get install gcc-snapshot -y
-  # - sudo apt-get update
-  # - sudo apt-get install gcc-7 -y
-
-  # - alias gcc="gcc-7"
-  # - CC="gcc-7"
-
-  # - which gcc
-  # - which gcc-7
-
-
-
   # Install GSL
   - sudo apt-get install libgsl0-dev -y
 
   # Install the dependencies and the package:
-  # - git clone https://github.com/tmcclintock/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
   - git clone https://github.com/matthewkirby/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
   - pip install -r requirements.txt
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,22 @@ python:
 - "3.6"
 
 install:
-  # Install GSL
+  # Update apt-get and install GSL
+  - sudo apt-get update
   - sudo apt-get install libgsl0-dev -y
 
-  # Install the dependencies and the package:
-  - git clone https://github.com/matthewkirby/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
+  # Install the dependencies
+  - git clone https://github.com/tmcclintock/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
   - pip install -r requirements.txt
+
+  # Install the package
   - python setup.py install
 
-  # Finally get set up to build the docs:
+  # Install dependencies required to test the docs
   - pip install sphinx==2.1.2
   - pip install sphinx_rtd_theme
 
 script:
-
   # Run the unit tests:
   - py.test --ignore=tests/crypt/ --ignore=cluster_toolkit/tests
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ install:
   - sudo apt-get update
 
   # Install an updated gcc
-  # - sudo apt install build-essential
-  - sudo add-apt-repository ppa:jonathonf/gcc-9.0
-  - sudo apt-get install gcc-9
+  - sudo apt install build-essential
+  # - sudo add-apt-repository ppa:jonathonf/gcc-9.0
+  # - sudo apt-get install gcc-9
   - CC="gcc-9"
 
   # Install GSL

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - sudo apt-get install libgsl0-dev -y
 
   # Install the dependencies and the package:
-  - git clone https://github.com/tmcclintock/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
+  - git clone https://github.com/tmcclintock/cluster_toolkit.git ; export LIBRARY_PATH=/home/travis/virtualenv/python3.6.3/lib/; cd cluster_toolkit ; python setup.py install ; cd -
   - pip install -r requirements.txt
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   # Install an updated gcc
   # - sudo apt-get install build-essential
   # - sudo add-apt-repository ppa:jonathonf/gcc-9.0 -y
-  - apt-cache search gcc-7
+  - apt-cache search gcc-6
   - sudo apt-get install gcc-7 -y
   - CC="gcc-7"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ install:
   - sudo apt-get update
   - sudo apt-get install gcc-snapshot -y
   - sudo apt-get update
-  - sudo apt-get install gcc-6 -y
+  - sudo apt-get install gcc-7 -y
 
-  - CC="gcc-6"
+  - CC="gcc-7"
 
   # Install GSL
   - sudo apt-get install libgsl0-dev -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   # Install an updated gcc
   # - sudo apt-get install build-essential
   # - sudo add-apt-repository ppa:jonathonf/gcc-9.0 -y
+  - apt-cache search gcc-7
   - sudo apt-get install gcc-7 -y
   - CC="gcc-7"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ install:
   - sudo apt-get install libgsl0-dev -y
 
   # Install the dependencies and the package:
-  - git clone https://github.com/tmcclintock/cluster_toolkit.git ; export LIBRARY_PATH=/home/travis/virtualenv/python3.6.3/lib/; cd cluster_toolkit ; python setup.py install ; cd -
+  # - git clone https://github.com/tmcclintock/cluster_toolkit.git ; export LIBRARY_PATH=/home/travis/virtualenv/python3.6.3/lib/; cd cluster_toolkit ; python setup.py install ; cd -
+  - git clone https://github.com/tmcclintock/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
   - pip install -r requirements.txt
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,24 +6,21 @@ python:
 - "3.6"
 
 install:
-  - sudo apt-get update
+  # - sudo apt-get update
 
   # Install an updated gcc
-  - sudo apt-get install build-essential software-properties-common -y
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update
-  - sudo apt-get install gcc-snapshot -y
-  - sudo apt-get update
-  - sudo apt-get install gcc-7 -y
-
-  # - sudo update-alternatives --remove-all gcc 
-  # - sudo update-alternatives --set gcc /usr/bin/gcc-7
+  # - sudo apt-get install build-essential software-properties-common -y
+  # - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  # - sudo apt-get update
+  # - sudo apt-get install gcc-snapshot -y
+  # - sudo apt-get update
+  # - sudo apt-get install gcc-7 -y
 
   # - alias gcc="gcc-7"
-  - CC="gcc-7"
+  # - CC="gcc-7"
 
-  - which gcc
-  - which gcc-7
+  # - which gcc
+  # - which gcc-7
 
 
 
@@ -31,8 +28,8 @@ install:
   - sudo apt-get install libgsl0-dev -y
 
   # Install the dependencies and the package:
-  # - git clone https://github.com/tmcclintock/cluster_toolkit.git ; export LIBRARY_PATH=/home/travis/virtualenv/python3.6.3/lib/; cd cluster_toolkit ; python setup.py install ; cd -
-  - git clone https://github.com/tmcclintock/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
+  # - git clone https://github.com/tmcclintock/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
+  - git clone https://github.com/matthewkirby/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
   - pip install -r requirements.txt
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 install:
   - sudo apt-get update
   - sudo apt-get install libgsl0-dev -y
+  - gcc --version
 
   # Install the dependencies and the package:
   - git clone https://github.com/matthewkirby/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,13 @@ install:
   - sudo apt-get update
 
   # Install an updated gcc
-  - sudo apt install build-essential
+  # - sudo apt install build-essential
+  - sudo add-apt-repository ppa:jonathonf/gcc-9.0
+  - sudo apt-get install gcc-9
+  - CC="gcc-9"
 
   # Install GSL
   - sudo apt-get install libgsl0-dev -y
-  - gcc --version
 
   # Install the dependencies and the package:
   - git clone https://github.com/tmcclintock/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,11 @@ install:
   # - alias gcc="gcc-7"
   - CC="gcc-7"
 
+  - which gcc
+  - which gcc-7
+
+
+
   # Install GSL
   - sudo apt-get install libgsl0-dev -y
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - sudo apt-get update
 
   # Install an updated gcc
-  - sudo apt install build-essential
+  - sudo apt-get install build-essential
   # - sudo add-apt-repository ppa:jonathonf/gcc-9.0
   # - sudo apt-get install gcc-9
   - CC="gcc-9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ install:
 
   # Install an updated gcc
   # - sudo apt-get install build-essential
-  - sudo add-apt-repository ppa:jonathonf/gcc-9.0 -y
-  - sudo apt-get install gcc-9 -y
-  - CC="gcc-9"
+  # - sudo add-apt-repository ppa:jonathonf/gcc-9.0 -y
+  - sudo apt-get install gcc-6 -y
+  - CC="gcc-6"
 
   # Install GSL
   - sudo apt-get install libgsl0-dev -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,16 @@ python:
 
 install:
   - sudo apt-get update
+
+  # Install an updated gcc
+  - sudo apt install build-essential
+
+  # Install GSL
   - sudo apt-get install libgsl0-dev -y
   - gcc --version
 
   # Install the dependencies and the package:
-  - git clone https://github.com/matthewkirby/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
+  - git clone https://github.com/tmcclintock/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
   - pip install -r requirements.txt
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ install:
   - sudo apt-get update
   - sudo apt-get install gcc-7 -y
 
+  - sudo update-alternatives --remove-all gcc 
+  - sudo update-alternatives --set gcc /usr/bin/gcc-7
+
   - CC="gcc-7"
 
   # Install GSL

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,14 @@ install:
   - sudo apt-get update
 
   # Install an updated gcc
-  # - sudo apt-get install build-essential
-  # - sudo add-apt-repository ppa:jonathonf/gcc-9.0 -y
-  - apt-cache search gcc-6
-  - sudo apt-get install gcc-7 -y
-  - CC="gcc-7"
+  - sudo apt-get install build-essential software-properties-common -y
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update
+  - sudo apt-get install gcc-snapshot -y
+  - sudo apt-get update
+  - sudo apt-get install gcc-6 -y
+
+  - CC="gcc-6"
 
   # Install GSL
   - sudo apt-get install libgsl0-dev -y

--- a/clmm/modeling.py
+++ b/clmm/modeling.py
@@ -148,7 +148,7 @@ def predict_surface_density(r_proj, mdelta, cdelta, cosmo, Delta=200, halo_profi
     Returns
     -------
     sigma : array_like, float
-        Surface density, Sigma in units of [h M_\\odot/$pc^2$]
+        Surface density, Sigma in units of [h Msun/$pc^2$]
 
     Notes
     -----
@@ -194,7 +194,7 @@ def predict_excess_surface_density(r_proj, mdelta, cdelta, cosmo, Delta=200, hal
     Returns
     -------
     deltasigma : array_like, float
-        Excess surface density, DeltaSigma in units of [h M_\\odot/$pc^2$].
+        Excess surface density, DeltaSigma in units of [h Msun/$pc^2$].
     """
     cosmo = cclify_astropy_cosmo(cosmo)
     Omega_m = cosmo['Omega_c'] + cosmo['Omega_b']
@@ -264,7 +264,7 @@ def get_critical_surface_density(cosmo, z_cluster, z_source):
     Returns
     -------
     sigmacrit : float
-        Cosmology-dependent critical surface density in units of h M_\odot/$pc^2$
+        Cosmology-dependent critical surface density in units of h Msun/pc^2
 
     Notes
     -----


### PR DESCRIPTION
This PR does two things
1. Installs cluster_toolkit on travis. The install uses my fork of the repo which has a small fix to allow gcc-4.8 to install the repo (simply changing `for(int i=0; i<x; i++)` to `int i; for(i=0; i<x; i++)` in two places). This should be fine since cltk is being ported to CCL anyways. We should not need any future functionality from the repo so this can probably stay using my fork until we remove it for CCL.

2. Fixed documentation crash. Sphinx was unhappy with `M_\odot` in docstrings. I think a future solution will need to escape `M`? For now I just changed it to `Msun` since the latex doesn't work anyways (this should be fixed but beyond the scope of this PR).

With this PR merged, we can check off one of the two goals in issue #120.

**ATTENTION REVIEWERS!!!**
When you go to merge, the big green button has a little arrow next to it and one of the options is "Squash and Merge". Most of my commits were miniscule adjustments to try to get travis working. If you look at the files changed tab, the end differences are tiny. This option will merge but with a single commit with a new commit message. The default is to combine all of the squashed messages. Lets just rewrite that.

We can squash all of this into a single commit with the message: "Travis now installs cluster_toolkit from matthewkirby fork to allow for gcc 4.8 compatability. Also changed M_\odot to Msun to resolve docstring bug."