### PR TITLE
Setup coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 cache: pip
 
 python:
-- "3.6"
+- "3.7"
 
 install:
   # Update apt-get and install GSL

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ install:
   - pip install sphinx==2.1.2
   - pip install sphinx_rtd_theme
 
+  # Install coveralls for test coverage
+  - pip install coveralls
+
 script:
   # Run the unit tests:
   - py.test --ignore=tests/crypt/ --ignore=cluster_toolkit/tests
@@ -28,3 +31,6 @@ script:
   # Run the docs:
   - sphinx-quickstart -a "travis" -p clmm -v 0.0.1 --ext-autodoc -q
   - make -C docs/ html
+
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ install:
   - pip install sphinx_rtd_theme
 
   # Install coveralls for test coverage
-  - pip install coveralls
+  - pip install coveralls pytest-cov
 
 script:
   # Run the unit tests:
-  - py.test --ignore=tests/crypt/ --ignore=cluster_toolkit/tests
+  - py.test tests/ --ignore=tests/crypt/ --ignore=cluster_toolkit/tests --cov=clmm/
 
   # Run the docs:
   - sphinx-quickstart -a "travis" -p clmm -v 0.0.1 --ext-autodoc -q

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# CLMM [![Documentation Status](https://readthedocs.org/projects/clmm/badge/?version=master)](https://clmm.readthedocs.io/en/master/?badge=master) [![Build Status](https://travis-ci.org/LSSTDESC/CLMM.svg?branch=master)](https://travis-ci.org/LSSTDESC/CLMM)
+# CLMM
+[![Build Status](https://travis-ci.org/LSSTDESC/CLMM.svg?branch=master)](https://travis-ci.org/LSSTDESC/CLMM) 
+[![Coverage Status](https://coveralls.io/repos/github/LSSTDESC/CLMM/badge.svg)](https://coveralls.io/github/LSSTDESC/CLMM)
+[![Documentation Status](https://readthedocs.org/projects/clmm/badge/?version=master)](https://clmm.readthedocs.io/en/master/?badge=master)
 
 The LSST-DESC Cluster Lensing Mass Modeling (CLMM) code is a Python library for performing galaxy cluster weak lensing analyses.
 clmm is associated with Key Tasks _DC1 SW+RQ_ and _DC2 SW_ of the LSST-DESC [Science Roadmap](https://lsstdesc.org/sites/default/files/DESC_SRM_V1_4.pdf) pertaining to absolute and relative mass calibration.


### PR DESCRIPTION
This PR sets up coveralls for code coverage of tests. It is run during travis and includes a badge on our readme with % coverage. If you click the badge you can go file by file and look at which lines are not hit during tests. 