### PR TITLE
Issue/231/Update bleeding edge to nightly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: pip
 
 python:
 - "3.6" # Minimum supported version
-- "3.8-dev" # Why not also test cutting edge?
+- "3.9-dev" # Why not also test cutting edge?
 
 install:
   # Update apt-get and install GSL

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
 jobs:
     allow_failures:
         - python: nightly
+    fast_finish: true
 
 install:
   # Update apt-get and install GSL

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: python
 cache: pip
 
 python:
-- "3.6" # Minimum supported version
-- "3.9-dev" # Why not also test cutting edge?
+# - "3.6" # Minimum supported version
+- "nightly" # Why not also test cutting edge?
 
 install:
   # Update apt-get and install GSL

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,13 @@ language: python
 cache: pip
 
 python:
-- "3.6" # Minimum supported version
-- "nightly" # Why not also test cutting edge?
+- 3.6
+- nightly
+
+# We don't want travis to fail if a new experimental feature breaks us
+jobs:
+    allow_failures:
+        - python: nightly
 
 install:
   # Update apt-get and install GSL

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 cache: pip
 
 python:
-# - "3.6" # Minimum supported version
+- "3.6" # Minimum supported version
 - "nightly" # Why not also test cutting edge?
 
 install:

--- a/clmm/__init__.py
+++ b/clmm/__init__.py
@@ -7,4 +7,4 @@ from .modeling import cclify_astropy_cosmo, get_reduced_shear_from_convergence, 
 from . import lsst
 
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'


### PR DESCRIPTION
We were running travis on 3.8-dev to test against the newest changes. Changed to nightly to avoid having to update this in the future. 

In general, failures on the `-dev` version and now `nightly` version can probably be safely ignored and put on the back-burner. No one using the code will be using these versions but they reflect potential future problems. To do this, I have also added the `allowed_failure` section to the config file for the `nightly` build.  If the `nightly` build fails we will see it but the overall travis build will pass (assuming `3.6` succeeds).