### PR TITLE
require astropy v4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python"
         ],
-      install_requires=["astropy", "numpy", "scipy"],
+      install_requires=["astropy>=4.0", "numpy", "scipy"],
       python_requires='>'+str(required_py_version)
 )
 


### PR DESCRIPTION
tries to fix #239.

It will work if you don't have astropy installed at all. However, though it looks like it works, the version of astropy does not seem to be updated if you already have an older version of astropy installed.