### PR TITLE
corrected errorbar: std/sqrt(n), not std/n

### DIFF
--- a/clmm/__init__.py
+++ b/clmm/__init__.py
@@ -7,4 +7,4 @@ from .modeling import cclify_astropy_cosmo, get_reduced_shear_from_convergence, 
 from . import lsst
 
 
-__version__ = '0.1.3'
+__version__ = '0.2.0'

--- a/clmm/__init__.py
+++ b/clmm/__init__.py
@@ -7,4 +7,4 @@ from .modeling import cclify_astropy_cosmo, get_reduced_shear_from_convergence, 
 from . import lsst
 
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'

--- a/clmm/polaraveraging.py
+++ b/clmm/polaraveraging.py
@@ -275,11 +275,11 @@ def make_shear_profile(cluster, angsep_units, bin_units, bins=10, cosmo=None,
 
     # Compute the binned average shears and associated errors
     r_avg, gt_avg, gt_err, nsrc = compute_radial_averages(
-        source_seps, cluster.galcat['gt'].data, xbins=bins, error_model='std/n')
+        source_seps, cluster.galcat['gt'].data, xbins=bins, error_model='std/sqrt_n')
     r_avg, gx_avg, gx_err, _ = compute_radial_averages(
-        source_seps, cluster.galcat['gx'].data, xbins=bins, error_model='std/n')
+        source_seps, cluster.galcat['gx'].data, xbins=bins, error_model='std/sqrt_n')
     r_avg, z_avg, z_err, _ = compute_radial_averages(
-        source_seps, cluster.galcat['z'].data, xbins=bins, error_model='std/n')
+        source_seps, cluster.galcat['z'].data, xbins=bins, error_model='std/sqrt_n')
 
     profile_table = Table([bins[:-1], r_avg, bins[1:], gt_avg, gt_err, gx_avg, gx_err,
                            z_avg, z_err, nsrc],

--- a/clmm/utils.py
+++ b/clmm/utils.py
@@ -4,7 +4,7 @@ from scipy.stats import binned_statistic
 from astropy import units as u
 
 
-def compute_radial_averages(xvals, yvals, xbins, error_model='std/n'):
+def compute_radial_averages(xvals, yvals, xbins, error_model='std/sqrt_n'):
     """ Given a list of xvalss, yvals and bins, sort into bins
 
     Parameters
@@ -17,7 +17,7 @@ def compute_radial_averages(xvals, yvals, xbins, error_model='std/n'):
         Bin edges to sort into
     error_model : str, optional
         Error model to use for y uncertainties.
-        std/n - Standard Deviation/Counts (Default)
+        std/sqrt_n - Standard Deviation/sqrt(Counts) (Default)
         std - Standard deviation
 
     Returns
@@ -38,9 +38,9 @@ def compute_radial_averages(xvals, yvals, xbins, error_model='std/n'):
 
     if error_model == 'std':
         yerr = binned_statistic(xvals, yvals, statistic='std', bins=xbins)[0]
-    elif error_model == 'std/n':
+    elif error_model == 'std/sqrt_n':
         yerr = binned_statistic(xvals, yvals, statistic='std', bins=xbins)[0]
-        yerr = yerr/binned_statistic(xvals, yvals, statistic='count', bins=xbins)[0]
+        yerr = yerr/np.sqrt(binned_statistic(xvals, yvals, statistic='count', bins=xbins)[0])
     else:
         raise ValueError(f"{error_model} not supported err model for binned stats")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,12 +23,12 @@ def test_compute_radial_averages():
 
     # Check the default error model
     assert_allclose(compute_radial_averages(binvals, binvals, xbins1),
-                    [[np.mean(binvals)], [np.mean(binvals)], [np.std(binvals)/len(binvals)], [6]],
+                    [[np.mean(binvals)], [np.mean(binvals)], [np.std(binvals)/np.sqrt(len(binvals))], [6]],
                     **TOLERANCE)
 
     # Test 3 objects in one bin with various error models
     assert_allclose(compute_radial_averages(binvals, binvals, xbins1, error_model='std/sqrt_n'),
-                    [[np.mean(binvals)], [np.mean(binvals)], [np.std(binvals)/len(binvals)], [6]],
+                    [[np.mean(binvals)], [np.mean(binvals)], [np.std(binvals)/np.sqrt(len(binvals))], [6]],
                     **TOLERANCE)
     assert_allclose(compute_radial_averages(binvals, binvals, xbins1, error_model='std'),
                     [[np.mean(binvals)], [np.mean(binvals)], [np.std(binvals)], [6]], **TOLERANCE)
@@ -38,7 +38,7 @@ def test_compute_radial_averages():
     inbin2 = binvals[(binvals > xbins2[1]) & (binvals < xbins2[2])]
     assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std/sqrt_n'),
                     [[np.mean(inbin1), np.mean(inbin2)], [np.mean(inbin1), np.mean(inbin2)],
-                     [np.std(inbin1)/len(inbin1), np.std(inbin2)/len(inbin2)], [3,3]], **TOLERANCE)
+                     [np.std(inbin1)/np.sqrt(len(inbin1)), np.std(inbin2)/np.sqrt(len(inbin2))], [3,3]], **TOLERANCE)
     assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std'),
                     [[np.mean(inbin1), np.mean(inbin2)], [np.mean(inbin1), np.mean(inbin2)],
                      [np.std(inbin1), np.std(inbin2)], [3,3]], **TOLERANCE)
@@ -52,8 +52,8 @@ def test_compute_radial_averages():
     assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std/sqrt_n'),
                     [[np.mean(inbin1), np.mean(inbin2), np.mean(inbin3)],
                      [np.mean(inbin1), np.mean(inbin2), np.mean(inbin3)],
-                     [np.std(inbin1)/len(inbin1), np.std(inbin2)/len(inbin2),
-                      np.std(inbin3)/len(inbin3)],
+                     [np.std(inbin1)/np.sqrt(len(inbin1)), np.std(inbin2)/np.sqrt(len(inbin2)),
+                      np.std(inbin3)/np.sqrt(len(inbin3))],
                      [inbin1.size, inbin2.size, inbin3.size]], **TOLERANCE)
     assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std'),
                     [[np.mean(inbin1), np.mean(inbin2), np.mean(inbin3)],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,7 @@ def test_compute_radial_averages():
                     **TOLERANCE)
 
     # Test 3 objects in one bin with various error models
-    assert_allclose(compute_radial_averages(binvals, binvals, xbins1, error_model='std/n'),
+    assert_allclose(compute_radial_averages(binvals, binvals, xbins1, error_model='std/sqrt_n'),
                     [[np.mean(binvals)], [np.mean(binvals)], [np.std(binvals)/len(binvals)], [6]],
                     **TOLERANCE)
     assert_allclose(compute_radial_averages(binvals, binvals, xbins1, error_model='std'),
@@ -36,7 +36,7 @@ def test_compute_radial_averages():
     # A slightly more complicated case with two bins
     inbin1 = binvals[(binvals > xbins2[0]) & (binvals < xbins2[1])]
     inbin2 = binvals[(binvals > xbins2[1]) & (binvals < xbins2[2])]
-    assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std/n'),
+    assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std/sqrt_n'),
                     [[np.mean(inbin1), np.mean(inbin2)], [np.mean(inbin1), np.mean(inbin2)],
                      [np.std(inbin1)/len(inbin1), np.std(inbin2)/len(inbin2)], [3,3]], **TOLERANCE)
     assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std'),
@@ -49,7 +49,7 @@ def test_compute_radial_averages():
     inbin1 = binvals[(binvals > xbins2[0]) & (binvals < xbins2[1])]
     inbin2 = binvals[(binvals > xbins2[1]) & (binvals < xbins2[2])]
     inbin3 = binvals[(binvals > xbins2[2]) & (binvals < xbins2[3])]
-    assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std/n'),
+    assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std/sqrt_n'),
                     [[np.mean(inbin1), np.mean(inbin2), np.mean(inbin3)],
                      [np.mean(inbin1), np.mean(inbin2), np.mean(inbin3)],
                      [np.std(inbin1)/len(inbin1), np.std(inbin2)/len(inbin2),


### PR DESCRIPTION
`polaraveraging.make_shear_profile` uses `compute_radial_averages` in `utils`, where the error bar is calculated by `std/n`. Corrected it to `std/numpy.sqrt(n)`. #205