### PR TITLE
Issue/252/gal_id_in_bins

### DIFF
--- a/clmm/__init__.py
+++ b/clmm/__init__.py
@@ -7,4 +7,4 @@ from .modeling import cclify_astropy_cosmo, get_reduced_shear_from_convergence, 
 from . import lsst
 
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'

--- a/clmm/polaraveraging.py
+++ b/clmm/polaraveraging.py
@@ -210,7 +210,7 @@ def _compute_cross_shear(shear1, shear2, phi):
 
 
 def make_shear_profile(cluster, angsep_units, bin_units, bins=10, cosmo=None,
-                       add_to_cluster=True, include_empty_bins=False):
+                       add_to_cluster=True, include_empty_bins=False, gal_ids_in_bins=False):
     r"""Compute the shear profile of the cluster
 
     We assume that the cluster object contains information on the cross and
@@ -248,6 +248,8 @@ def make_shear_profile(cluster, angsep_units, bin_units, bins=10, cosmo=None,
         Attach the profile to the cluster object as `cluster.profile`
     include_empty_bins: bool, optional
         Also include empty bins in the returned table
+    gal_ids_in_bins: bool, optional
+        Also include the list of galaxies ID belonging to each bin in the returned table
 
     Returns
     -------
@@ -261,7 +263,7 @@ def make_shear_profile(cluster, angsep_units, bin_units, bins=10, cosmo=None,
                         'and cross shears (gt,gx). Run compute_shear first!')
     if 'z' not in cluster.galcat.columns:
         raise TypeError('Missing galaxy redshifts!')
-
+    
     # Check to see if we need to do a unit conversion
     if angsep_units is not bin_units:
         source_seps = convert_units(cluster.galcat['theta'], angsep_units, bin_units,
@@ -274,17 +276,29 @@ def make_shear_profile(cluster, angsep_units, bin_units, bins=10, cosmo=None,
         bins = make_bins(np.min(source_seps), np.max(source_seps), bins)
 
     # Compute the binned average shears and associated errors
-    r_avg, gt_avg, gt_err, nsrc = compute_radial_averages(
+    r_avg, gt_avg, gt_err, nsrc, binnumber = compute_radial_averages(
         source_seps, cluster.galcat['gt'].data, xbins=bins, error_model='std/sqrt_n')
-    r_avg, gx_avg, gx_err, _ = compute_radial_averages(
+    r_avg, gx_avg, gx_err, _, _ = compute_radial_averages(
         source_seps, cluster.galcat['gx'].data, xbins=bins, error_model='std/sqrt_n')
-    r_avg, z_avg, z_err, _ = compute_radial_averages(
+    r_avg, z_avg, z_err, _, _ = compute_radial_averages(
         source_seps, cluster.galcat['z'].data, xbins=bins, error_model='std/sqrt_n')
 
-    profile_table = Table([bins[:-1], r_avg, bins[1:], gt_avg, gt_err, gx_avg, gx_err,
-                           z_avg, z_err, nsrc],
-                          names=('radius_min', 'radius', 'radius_max', 'gt', 'gt_err',
+
+    if not gal_ids_in_bins:
+        profile_table = Table([bins[:-1], r_avg, bins[1:], gt_avg, gt_err, gx_avg, gx_err,
+                               z_avg, z_err, nsrc],
+                               names=('radius_min', 'radius', 'radius_max', 'gt', 'gt_err',
                                  'gx', 'gx_err', 'z', 'z_err', 'n_src'))
+    else:
+        if 'id' not in cluster.galcat.columns:
+            raise TypeError('Missing galaxy IDs!')
+        mask = [binnumber==i+1 for i in np.arange(len(r_avg))]
+        gal_id = [list(cluster.galcat['id'][mask[i]]) for i in np.arange(len(r_avg))]
+        profile_table = Table([bins[:-1], r_avg, bins[1:], gt_avg, gt_err, gx_avg, gx_err,
+                               z_avg, z_err, nsrc, gal_id],
+                               names=('radius_min', 'radius', 'radius_max', 'gt', 'gt_err',
+                                 'gx', 'gx_err', 'z', 'z_err', 'n_src', 'gal_id'))
+
     # return empty bins?
     if not include_empty_bins:
         profile_table = profile_table[profile_table['n_src'] > 1]

--- a/clmm/polaraveraging.py
+++ b/clmm/polaraveraging.py
@@ -292,8 +292,7 @@ def make_shear_profile(cluster, angsep_units, bin_units, bins=10, cosmo=None,
     else:
         if 'id' not in cluster.galcat.columns:
             raise TypeError('Missing galaxy IDs!')
-        mask = [binnumber==i+1 for i in np.arange(len(r_avg))]
-        gal_id = [list(cluster.galcat['id'][mask[i]]) for i in np.arange(len(r_avg))]
+        gal_id = [list(cluster.galcat['id'][binnumber==i+1]) for i in np.arange(len(r_avg))]
         profile_table = Table([bins[:-1], r_avg, bins[1:], gt_avg, gt_err, gx_avg, gx_err,
                                z_avg, z_err, nsrc, gal_id],
                                names=('radius_min', 'radius', 'radius_max', 'gt', 'gt_err',

--- a/clmm/utils.py
+++ b/clmm/utils.py
@@ -31,7 +31,7 @@ def compute_radial_averages(xvals, yvals, xbins, error_model='std/sqrt_n'):
     n : array_like
         Number of objects in each bin
     """
-    meanx, xbins = binned_statistic(xvals, xvals, statistic='mean', bins=xbins)[:2]
+    meanx, xbins, binnumber = binned_statistic(xvals, xvals, statistic='mean', bins=xbins)[:3]
     meany = binned_statistic(xvals, yvals, statistic='mean', bins=xbins)[0]
     # number of objects
     n = np.histogram(xvals, xbins)[0]
@@ -44,7 +44,7 @@ def compute_radial_averages(xvals, yvals, xbins, error_model='std/sqrt_n'):
     else:
         raise ValueError(f"{error_model} not supported err model for binned stats")
 
-    return meanx, meany, yerr, n
+    return meanx, meany, yerr, n, binnumber
 
 
 def make_bins(rmin, rmax, nbins=10, method='evenwidth'):

--- a/examples/demo_polaraveraging_functionality.ipynb
+++ b/examples/demo_polaraveraging_functionality.ipynb
@@ -31,9 +31,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -72,9 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from astropy.cosmology import FlatLambdaCDM\n",
@@ -85,7 +81,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1) Generate cluster object with mock data with shape noise, galaxies from redshift distribution and a pdz for each source galaxy"
+    "### 1. Generate cluster object with mock data with shape noise, galaxies from redshift distribution and a pdz for each source galaxy"
    ]
   },
   {
@@ -98,9 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "cosmo = mock_cosmo\n",
@@ -135,9 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "cluster_ra = 0.0\n",
@@ -150,7 +142,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2) Load cluster object containing:\n",
+    "### 2. Load cluster object containing:\n",
     "> Lens properties (ra_l, dec_l, z_l)\n",
     "\n",
     "> Source properties (ra_s, dec_s, e1, e2)\n",
@@ -239,7 +231,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3) Compute and plot shear profiles"
+    "### 3. Compute and plot shear profiles"
    ]
   },
   {
@@ -252,9 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "theta, g_t, g_x = compute_shear(cl, geometry=\"flat\")"
@@ -387,13 +377,47 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": true
    },
+   "source": [
+    "### 4. Focus on some options\n",
+    "4.1. The `gal_ids_in_bins` option adds a `gal_id` field to the profile astropy table. For each bin of the profile, this is filled with the list of galaxy IDs for the galaxies that have fallen in that bin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "profiles = make_shear_profile(cl, \"radians\", \"kpc\", cosmo=cosmo, gal_ids_in_bins=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Here the list of galaxy IDs that are in the first bin of the tangential shear profile\n",
+    "import numpy as np\n",
+    "gal_list = profiles['gal_id'][0]\n",
+    "print(gal_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can then use that list to recover information of this subset of \n",
+    "# galaxies in the original galaxy catalog\n",
+    "\n",
+    "cl.galcat[gal_list]"
+   ]
   }
  ],
  "metadata": {
@@ -412,7 +436,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,26 +22,31 @@ def test_compute_radial_averages():
     assert_raises(ValueError, compute_radial_averages, binvals, binvals, [0., 10.], 'glue')
 
     # Check the default error model
-    assert_allclose(compute_radial_averages(binvals, binvals, xbins1),
-                    [[np.mean(binvals)], [np.mean(binvals)], [np.std(binvals)/np.sqrt(len(binvals))], [6]],
+    assert_allclose(compute_radial_averages(binvals, binvals, xbins1)[:4],
+                    [[np.mean(binvals)], [np.mean(binvals)], [np.std(binvals)/np.sqrt(len(binvals))],
+                    [6]],
                     **TOLERANCE)
 
+
     # Test 3 objects in one bin with various error models
-    assert_allclose(compute_radial_averages(binvals, binvals, xbins1, error_model='std/sqrt_n'),
+    assert_allclose(compute_radial_averages(binvals, binvals, xbins1, error_model='std/sqrt_n')[:4],
                     [[np.mean(binvals)], [np.mean(binvals)], [np.std(binvals)/np.sqrt(len(binvals))], [6]],
                     **TOLERANCE)
-    assert_allclose(compute_radial_averages(binvals, binvals, xbins1, error_model='std'),
-                    [[np.mean(binvals)], [np.mean(binvals)], [np.std(binvals)], [6]], **TOLERANCE)
+    assert_allclose(compute_radial_averages(binvals, binvals, xbins1, error_model='std')[:4],
+                    [[np.mean(binvals)], [np.mean(binvals)], [np.std(binvals)], 
+                    [6]], **TOLERANCE)
 
     # A slightly more complicated case with two bins
     inbin1 = binvals[(binvals > xbins2[0]) & (binvals < xbins2[1])]
     inbin2 = binvals[(binvals > xbins2[1]) & (binvals < xbins2[2])]
-    assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std/sqrt_n'),
+    assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std/sqrt_n')[:4],
                     [[np.mean(inbin1), np.mean(inbin2)], [np.mean(inbin1), np.mean(inbin2)],
-                     [np.std(inbin1)/np.sqrt(len(inbin1)), np.std(inbin2)/np.sqrt(len(inbin2))], [3,3]], **TOLERANCE)
-    assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std'),
+                     [np.std(inbin1)/np.sqrt(len(inbin1)), np.std(inbin2)/np.sqrt(len(inbin2))],
+                     [3,3]], **TOLERANCE)
+    assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std')[:4],
                     [[np.mean(inbin1), np.mean(inbin2)], [np.mean(inbin1), np.mean(inbin2)],
-                     [np.std(inbin1), np.std(inbin2)], [3,3]], **TOLERANCE)
+                     [np.std(inbin1), np.std(inbin2)], 
+                     [3,3]], **TOLERANCE)
 
     # Test a much larger, random sample with unevenly spaced bins
     binvals = np.loadtxt('tests/data/radial_average_test_array.txt')
@@ -49,13 +54,13 @@ def test_compute_radial_averages():
     inbin1 = binvals[(binvals > xbins2[0]) & (binvals < xbins2[1])]
     inbin2 = binvals[(binvals > xbins2[1]) & (binvals < xbins2[2])]
     inbin3 = binvals[(binvals > xbins2[2]) & (binvals < xbins2[3])]
-    assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std/sqrt_n'),
+    assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std/sqrt_n')[:4],
                     [[np.mean(inbin1), np.mean(inbin2), np.mean(inbin3)],
                      [np.mean(inbin1), np.mean(inbin2), np.mean(inbin3)],
                      [np.std(inbin1)/np.sqrt(len(inbin1)), np.std(inbin2)/np.sqrt(len(inbin2)),
                       np.std(inbin3)/np.sqrt(len(inbin3))],
                      [inbin1.size, inbin2.size, inbin3.size]], **TOLERANCE)
-    assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std'),
+    assert_allclose(compute_radial_averages(binvals, binvals, xbins2, error_model='std')[:4],
                     [[np.mean(inbin1), np.mean(inbin2), np.mean(inbin3)],
                      [np.mean(inbin1), np.mean(inbin2), np.mean(inbin3)],
                      [np.std(inbin1), np.std(inbin2), np.std(inbin3)],


### PR DESCRIPTION
This addresses #252 to optionally return the list of galaxy IDs that fall in a given bin in the shear profile astropy table. The steps taken were:

- [x] Return the `binnumber` from `binned_statistics` in `compute_radial_averages` (in `utils.py`) 
- [x] Add an option in `make_shear_profile` to allow for an extra optional field in the resulting astropy table. This field will contain the list of ids of galaxies in each radial bins
- [x] In `make_shear_profile`, use `binnumber` to filter on the galaxy catalog and return the IDs of the galaxies in each bin.
- [x] Add a test in `test_polaraveraging` to check the new option.
- [x] Update the `demo_of_polaraveraging` notebook to highlight the use of this option in a new section at the end.