### PR TITLE
Issue/262/hard coded range in modeling

### DIFF
--- a/clmm/modeling.py
+++ b/clmm/modeling.py
@@ -267,11 +267,11 @@ def predict_excess_surface_density(r_proj, mdelta, cdelta, z_cl, cosmo, delta_md
     omega_m = cosmo['Omega_c'] + cosmo['Omega_b']
     omega_m_transformed = _patch_zevolution_cluster_toolkit_rho_m(omega_m, z_cl)
 
-    if r_proj[0]<1.e-11:
-        raise ValueError(f"Rmin = {r_proj[0]:.2e} Mpc/h! This value is too small and may cause computational issues.")
+    if np.min(r_proj)<1.e-11:
+        raise ValueError(f"Rmin = {np.min(r_proj):.2e} Mpc/h! This value is too small and may cause computational issues.")
 
     # Computing sigma on a larger range than the radial range requested
-    sigma_r_proj = np.logspace(np.log10(r_proj[0])-1, np.log10(r_proj[-1])+1, len(r_proj)*10)
+    sigma_r_proj = np.logspace(np.log10(np.min(r_proj))-1, np.log10(np.max(r_proj))+1, len(r_proj)*10)
 
     if halo_profile_model.lower() == 'nfw':
         sigma = ct.deltasigma.Sigma_nfw_at_R(sigma_r_proj, mdelta, cdelta,

--- a/clmm/modeling.py
+++ b/clmm/modeling.py
@@ -268,7 +268,8 @@ def predict_excess_surface_density(r_proj, mdelta, cdelta, z_cl, cosmo, delta_md
     omega_m = cosmo['Omega_c'] + cosmo['Omega_b']
     omega_m_transformed = _patch_zevolution_cluster_toolkit_rho_m(omega_m, z_cl)
 
-    sigma_r_proj = np.logspace(np.log10(r_proj[0]), np.log10(r_proj[-1]), 1000)
+    # Computing sigma on a larger range than the radial range requested
+    sigma_r_proj = np.logspace(np.log10(r_proj[0])-1, np.log10(r_proj[-1])+1, len(r_proj)*10)
 
     if halo_profile_model.lower() == 'nfw':
         sigma = ct.deltasigma.Sigma_nfw_at_R(sigma_r_proj, mdelta, cdelta,

--- a/clmm/modeling.py
+++ b/clmm/modeling.py
@@ -268,7 +268,7 @@ def predict_excess_surface_density(r_proj, mdelta, cdelta, z_cl, cosmo, delta_md
     omega_m = cosmo['Omega_c'] + cosmo['Omega_b']
     omega_m_transformed = _patch_zevolution_cluster_toolkit_rho_m(omega_m, z_cl)
 
-    sigma_r_proj = np.logspace(-3, 4, 1000)
+    sigma_r_proj = np.logspace(np.log10(r_proj[0]), np.log10(r_proj[-1]), 1000)
 
     if halo_profile_model.lower() == 'nfw':
         sigma = ct.deltasigma.Sigma_nfw_at_R(sigma_r_proj, mdelta, cdelta,

--- a/clmm/modeling.py
+++ b/clmm/modeling.py
@@ -5,7 +5,6 @@ from astropy import units
 from astropy.cosmology import LambdaCDM
 from .constants import Constants as const
 from .cluster_toolkit_patches import _patch_zevolution_cluster_toolkit_rho_m
-import warnings
 
 def cclify_astropy_cosmo(cosmoin):
     """ Given an astropy.cosmology object, creates a CCL-like dictionary

--- a/clmm/modeling.py
+++ b/clmm/modeling.py
@@ -5,7 +5,7 @@ from astropy import units
 from astropy.cosmology import LambdaCDM
 from .constants import Constants as const
 from .cluster_toolkit_patches import _patch_zevolution_cluster_toolkit_rho_m
-
+import warnings
 
 def cclify_astropy_cosmo(cosmoin):
     """ Given an astropy.cosmology object, creates a CCL-like dictionary
@@ -267,6 +267,9 @@ def predict_excess_surface_density(r_proj, mdelta, cdelta, z_cl, cosmo, delta_md
     cosmo = cclify_astropy_cosmo(cosmo)
     omega_m = cosmo['Omega_c'] + cosmo['Omega_b']
     omega_m_transformed = _patch_zevolution_cluster_toolkit_rho_m(omega_m, z_cl)
+
+    if r_proj[0]<1.e-11:
+        raise ValueError(f"Rmin = {r_proj[0]:.2e} Mpc/h! This value is too small and may cause computational issues.")
 
     # Computing sigma on a larger range than the radial range requested
     sigma_r_proj = np.logspace(np.log10(r_proj[0])-1, np.log10(r_proj[-1])+1, len(r_proj)*10)

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -365,7 +365,7 @@ def test_shear_convergence_unittests():
     sigmac_corr = sigma_c_undo/sigma_c/sigcrit_corr
 
     # Chech error is raised if too small radius   
-    assert_raises(TypeError, md.predict_tangential_shear, 1.e-12, 1.e15, 4, 0.2, 0.45, cosmo)
+    assert_raises(ValueError, md.predict_tangential_shear, 1.e-12, 1.e15, 4, 0.2, 0.45, cosmo)
 
     # Validate tangential shear
     gammat = md.predict_tangential_shear(cosmo=cosmo, **cfg['GAMMA_PARAMS'])

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -364,6 +364,9 @@ def test_shear_convergence_unittests():
 +                                               cfg['z_source'])
     sigmac_corr = sigma_c_undo/sigma_c/sigcrit_corr
 
+    # Chech error is raised if too small radius   
+    assert_raises(TypeError, md.predict_tangential_shear, 1.e-12, 1.e15, 4, 0.2, 0.45, cosmo)
+
     # Validate tangential shear
     gammat = md.predict_tangential_shear(cosmo=cosmo, **cfg['GAMMA_PARAMS'])
     assert_allclose(gammat*sigmac_corr, cfg['numcosmo_profiles']['gammat'], 1.0e-8)


### PR DESCRIPTION
This addresses #262. The changes are:
- [x] New definition of `sigma_r_proj`, that now depends on the user-defined radial range over which to compute DeltaSigma: `sigma_r_proj = np.logspace(np.log10(np.min(r_proj))-1, np.log10(np.max(r_proj))+1, len(r_proj)*10)` in `predict_excess_surface_density`;
- [x] Raise an error for very small radii (<1.e-11 Mpc/h) in DeltaSigma, where the kernel is consistently crashing.
- [x] Add test in `test_modeling.py` to check the error is raised accordingly