### PR TITLE
Issue/285/reorganization

### DIFF
--- a/clmm/__init__.py
+++ b/clmm/__init__.py
@@ -1,10 +1,13 @@
 """ CLMM is a cluster mass modeling code. """
 from .gcdata import GCData
 from .galaxycluster import GalaxyCluster
+
+from .dataops import compute_tangential_and_cross_components
 from .hybrid import make_binned_profile, convert_units
-from .polaraveraging import compute_tangential_and_cross_components
-from .utils import compute_radial_averages, make_bins
-from .modeling import cclify_astropy_cosmo, get_reduced_shear_from_convergence, get_3d_density, predict_surface_density, predict_excess_surface_density, angular_diameter_dist_a1a2, get_critical_surface_density, predict_tangential_shear, predict_convergence, predict_reduced_tangential_shear
+from .modeling import cclify_astropy_cosmo, get_3d_density, predict_surface_density, predict_excess_surface_density, angular_diameter_dist_a1a2, get_critical_surface_density, predict_tangential_shear, predict_convergence, predict_reduced_tangential_shear, astropyify_ccl_cosmo, predict_magnification
+# from .modeling import _convert_rad_to_mpc
+from .utils import compute_radial_averages, make_bins, convert_shapes_to_epsilon, build_ellipticities, compute_lensed_ellipticity, get_reduced_shear_from_convergence
+# from .utils import _get_a_from_z, _get_z_from_a, _compute_tangential_shear, _compute_cross_shear, _compute_lensing_angles_flatsky
 
 from . import lsst
 

--- a/clmm/__init__.py
+++ b/clmm/__init__.py
@@ -1,8 +1,9 @@
 """ CLMM is a cluster mass modeling code. """
 from .gcdata import GCData
 from .galaxycluster import GalaxyCluster
-from .polaraveraging import compute_tangential_and_cross_components, make_binned_profile
-from .utils import compute_radial_averages, make_bins, convert_units
+from .hybrid import make_binned_profile, convert_units
+from .polaraveraging import compute_tangential_and_cross_components
+from .utils import compute_radial_averages, make_bins
 from .modeling import cclify_astropy_cosmo, get_reduced_shear_from_convergence, get_3d_density, predict_surface_density, predict_excess_surface_density, angular_diameter_dist_a1a2, get_critical_surface_density, predict_tangential_shear, predict_convergence, predict_reduced_tangential_shear
 
 from . import lsst

--- a/clmm/constants.py
+++ b/clmm/constants.py
@@ -1,7 +1,7 @@
 """ Provide a consistent set of constants to use through CLMM """
-from enum import Enum
 import astropy.constants as astropyconst
 import astropy.units as u
+from enum import Enum
 
 
 class Constants(Enum):

--- a/clmm/dataops.py
+++ b/clmm/dataops.py
@@ -8,11 +8,8 @@ import warnings
 
 from .galaxycluster import GalaxyCluster
 from .gcdata import GCData
-from .utils import compute_radial_averages, make_bins, convert_units, _compute_tangential_shear, _compute_cross_shear
-
 from .hybrid import make_binned_profile
-from .modeling import cclify_astropy_cosmo, angular_diameter_dist_a1a2, predict_tangential_shear, predict_convergence, predict_reduced_tangential_shear, astropyify_ccl_cosmo, predict_magnification
-from .utils import compute_radial_averages, make_bins, convert_shapes_to_epsilon, build_ellipticities, compute_lensed_ellipticity, get_reduced_shear_from_convergence
+from .utils import _compute_tangential_shear, _compute_cross_shear, _compute_lensing_angles_flatsky
 
 
 def compute_tangential_and_cross_components(cluster=None, shape_component1='e1', shape_component2='e2', tan_component='et', cross_component='ex', ra_lens=None, dec_lens=None, ra_source_list=None, dec_source_list=None, shear1=None, shear2=None, geometry='flat', add_to_cluster=True):

--- a/clmm/dataops.py
+++ b/clmm/dataops.py
@@ -1,22 +1,21 @@
-"""Functions to compute polar/azimuthal averages of data in radial bins"""
+"""Functions to compute polar/azimuthal averages of data in radial bins (formerly known as polaraveraging.py)"""
 # try: # 7481794
 #     import pyccl as ccl
 # except ImportError:
 #     pass
-import math
-import warnings
 import numpy as np
-from .gcdata import GCData
-from .utils import compute_radial_averages, make_bins, convert_units
+import warnings
+
 from .galaxycluster import GalaxyCluster
+from .gcdata import GCData
+from .utils import compute_radial_averages, make_bins, convert_units, _compute_tangential_shear, _compute_cross_shear
+
+from .hybrid import make_binned_profile
+from .modeling import cclify_astropy_cosmo, angular_diameter_dist_a1a2, predict_tangential_shear, predict_convergence, predict_reduced_tangential_shear, astropyify_ccl_cosmo, predict_magnification
+from .utils import compute_radial_averages, make_bins, convert_shapes_to_epsilon, build_ellipticities, compute_lensed_ellipticity, get_reduced_shear_from_convergence
 
 
-def compute_tangential_and_cross_components(cluster=None,
-                  shape_component1='e1', shape_component2='e2',
-                  tan_component='et', cross_component='ex',
-                  ra_lens=None, dec_lens=None, ra_source_list=None,
-                  dec_source_list=None, shear1=None, shear2=None, geometry='flat',
-                  add_to_cluster=True):
+def compute_tangential_and_cross_components(cluster=None, shape_component1='e1', shape_component2='e2', tan_component='et', cross_component='ex', ra_lens=None, dec_lens=None, ra_source_list=None, dec_source_list=None, shear1=None, shear2=None, geometry='flat', add_to_cluster=True):
     r"""Computes tangential- and cross- components for shear or ellipticity
 
     To compute the shear, we need the right ascension and declination of the lens and of
@@ -31,7 +30,7 @@ def compute_tangential_and_cross_components(cluster=None,
     2. Given a `GalaxyCluster` object::
 
         compute_shear(cluster)
-
+_compute_cross_shear
     3. As a method of `GalaxyCluster`::
 
         cluster.compute_shear()
@@ -76,7 +75,7 @@ def compute_tangential_and_cross_components(cluster=None,
     tan_component: string, optional
         Name of the column to be added to the `galcat` astropy table that will contain the
         tangential component computed from columns `shape_component1` and `shape_component2`.
-        Default: `et`
+        Default: `et`_compute_cross_shear
     cross_component: string, optional
         Name of the column to be added to the `galcat` astropy table that will contain the
         cross component computed from columns `shape_component1` and `shape_component2`.
@@ -149,76 +148,6 @@ def compute_tangential_and_cross_components(cluster=None,
         cluster.galcat[cross_component] = cross_shear
 
     return angsep, tangential_shear, cross_shear
-
-
-def _compute_lensing_angles_flatsky(ra_lens, dec_lens, ra_source_list, dec_source_list):
-    r"""Compute the angular separation between the lens and the source and the azimuthal
-    angle from the lens to the source in radians.
-
-    In the flat sky approximation, these angles are calculated using
-    .. math::
-        \theta = \sqrt{\left(\delta_s - \delta_l\right)^2 +
-        \left(\alpha_l-\alpha_s\right)^2\cos^2(\delta_l)}
-
-        \tan\phi = \frac{\delta_s - \delta_l}{\left(\alpha_l - \alpha_s\right)\cos(\delta_l)}
-
-    For extended descriptions of parameters, see `compute_shear()` documentation.
-    """
-    if not -360. <= ra_lens <= 360.:
-        raise ValueError(f"ra = {ra_lens} of lens if out of domain")
-    if not -90. <= dec_lens <= 90.:
-        raise ValueError(f"dec = {dec_lens} of lens if out of domain")
-    if not all(-360. <= x_ <= 360. for x_ in ra_source_list):
-        raise ValueError("Cluster has an invalid ra in source catalog")
-    if not all(-90. <= x_ <= 90 for x_ in dec_source_list):
-        raise ValueError("Cluster has an invalid dec in the source catalog")
-
-    # Put angles between -pi and pi
-    r2pi = lambda x: x - np.round(x/(2.0*math.pi))*2.0*math.pi
-
-    deltax = r2pi (np.radians(ra_source_list - ra_lens)) * math.cos(math.radians(dec_lens))
-    deltay = np.radians(dec_source_list - dec_lens)
-
-    # Ensure that abs(delta ra) < pi
-    #deltax[deltax >= np.pi] = deltax[deltax >= np.pi] - 2.*np.pi
-    #deltax[deltax < -np.pi] = deltax[deltax < -np.pi] + 2.*np.pi
-
-    angsep = np.sqrt(deltax**2 + deltay**2)
-    phi = np.arctan2(deltay, -deltax)
-    # Forcing phi to be zero everytime angsep is zero. This is necessary due to arctan2 features (it returns ).
-    phi[angsep==0.0] = 0.0
-
-    if np.any(angsep > np.pi/180.):
-        warnings.warn("Using the flat-sky approximation with separations >1 deg may be inaccurate")
-
-    return angsep, phi
-
-
-def _compute_tangential_shear(shear1, shear2, phi):
-    r"""Compute the tangential shear given the two shears and azimuthal positions for
-    a single source or list of sources.
-
-    We compute the tangential shear following Eq. 7 of Schrabback et al. 2018, arXiv:1611:03866
-    .. math::
-        g_t = -\left( g_1\cos\left(2\phi\right) - g_2\sin\left(2\phi\right)\right)
-
-    For extended descriptions of parameters, see `compute_shear()` documentation.
-    """
-    return - (shear1 * np.cos(2.*phi) + shear2 * np.sin(2.*phi))
-
-
-def _compute_cross_shear(shear1, shear2, phi):
-    r"""Compute the cross shear given the two shears and azimuthal position for a single
-    source of list of sources.
-
-    We compute the cross shear following Eq. 8 of Schrabback et al. 2018, arXiv:1611:03866
-    also checked arxiv 0509252
-    .. math::
-        g_x = g_1 \sin\left(2\phi\right) - g_2\cos\left(2\phi\right)
-
-    For extended descriptions of parameters, see `compute_shear()` documentation.
-    """
-    return shear1 * np.sin(2.*phi) - shear2 * np.cos(2.*phi)
 
 
 # Monkey patch functions onto Galaxy Cluster object

--- a/clmm/galaxycluster.py
+++ b/clmm/galaxycluster.py
@@ -29,6 +29,7 @@ class GalaxyCluster():
         if len(args)>0 or len(kwargs)>0:
             self._add_values(*args, **kwargs)
             self._check_types()
+
     def _add_values(self, unique_id: str, ra: float, dec: float, z: float,
                  galcat: GCData):
         """Add values for all attributes"""
@@ -38,6 +39,7 @@ class GalaxyCluster():
         self.z = z
         self.galcat = galcat
         return
+
     def _check_types(self):
         """Check types of all attributes"""
         if isinstance(self.unique_id, (int, str)): # should unique_id be a float?
@@ -66,17 +68,20 @@ class GalaxyCluster():
         if self.z < 0.:
             raise ValueError(f'z={self.z} must be greater than 0')
         return
+
     def save(self, filename, **kwargs):
         """Saves GalaxyCluster object to filename using Pickle"""
         with open(filename, 'wb') as fin:
             pickle.dump(self, fin, **kwargs)
         return
+
     def load(filename, **kwargs):
         """Loads GalaxyCluster object to filename using Pickle"""
         with open(filename, 'rb') as fin:
             self = pickle.load(fin, **kwargs)
         self._check_types()
         return self
+
     def __repr__(self):
         """Generates string for print(GalaxyCluster)"""
         output = f'GalaxyCluster {self.unique_id}: ' +\

--- a/clmm/gcdata.py
+++ b/clmm/gcdata.py
@@ -22,6 +22,7 @@ class GCData(APtable):
         *args, **kwargs: Same used for astropy tables
         """
         APtable.__init__(self, *args, **kwargs)
+
     def add_meta(self, name, value):
         """
         Add metadata to GCData
@@ -39,6 +40,7 @@ class GCData(APtable):
         """
         self.meta[name] = value
         return
+
     def add_metas(self, names, values):
         """
         Add metadatas to GCData
@@ -57,6 +59,7 @@ class GCData(APtable):
         for name, vale in zip(names, values):
             self.add_meta(name, value)
         return
+
     def __repr__(self):
         """Generates string for repr(GCData)"""
         output = f'{self.__class__.__name__}('
@@ -65,6 +68,7 @@ class GCData(APtable):
             + ['columns: '+', '.join(self.colnames)])
         output += ')'
         return output
+
     def __str__(self):
         """Generates string for print(GCData)"""
         output = f'self.__class__.__name__\n> defined by:'
@@ -73,6 +77,7 @@ class GCData(APtable):
         output += f'\n> with columns: '
         output += ', '.join(self.colnames)
         return output
+        
     def __getitem__(self, item):
         """
         Makes sure GCData keeps its properties after [] operations are used
@@ -159,5 +164,5 @@ Note: Not being used anymore
 #        for match in found:
 #            if check_subdict(match.specs, lookup_specs):
 #                return [match]
-#        found = [] 
+#        found = []
 #    return found

--- a/clmm/hybrid.py
+++ b/clmm/hybrid.py
@@ -1,4 +1,7 @@
-"""Functions requiring both data and model assumptions"""
+"""Functions requiring both model and GCData assumptions"""
+
+from astropy import units as u
+
 # function pointer instead of keywords as cosmo.sigma_crit_filter
 # compute tangential and cross in util and appears in calls for polaraveraging
 #
@@ -9,32 +12,6 @@
 #
 # agnostic version in utils, can call directly if user specifies everything or call from 3 modules with our objects
 # base versions in util, dataoperations in
-
-def _convert_rad_to_mpc(dist1, redshift, cosmo, do_inverse=False):
-    r""" Convert between radians and Mpc using the small angle approximation
-    and :math:`d = D_A \theta`.
-
-    Parameters
-    ==========
-    dist1 : array_like
-        Input distances
-    redshift : float
-        Redshift used to convert between angular and physical units
-    cosmo : astropy.cosmology
-        Astropy cosmology object to compute angular diameter distance to
-        convert between physical and angular units
-    do_inverse : bool
-        If true, converts Mpc to radians
-
-    Returns
-    =======
-    dist2 : array_like
-        Converted distances
-    """
-    d_a = cosmo.angular_diameter_distance(redshift).to('Mpc').value
-    if do_inverse:
-        return dist1 / d_a
-    return dist1 * d_a
 
 def convert_units(dist1, unit1, unit2, redshift=None, cosmo=None):
     """ Convenience wrapper to convert between a combination of angular and physical units.
@@ -62,6 +39,10 @@ def convert_units(dist1, unit1, unit2, redshift=None, cosmo=None):
     -------
     dist2: array_like
         Input distances converted to unit2
+
+    Notes
+    -----
+    Should we make this two separate functions, one cosmology-dependent and one cosmology-independent?
     """
     angular_bank = {"radians": u.rad, "degrees": u.deg, "arcmin": u.arcmin, "arcsec": u.arcsec}
     physical_bank = {"pc": u.pc, "kpc": u.kpc, "Mpc": u.Mpc}
@@ -99,11 +80,7 @@ def convert_units(dist1, unit1, unit2, redshift=None, cosmo=None):
         return (dist1_rad * u.rad).to(units_bank[unit2]).value
 
 
-def make_binned_profile(cluster,
-                       angsep_units, bin_units, bins=10, cosmo=None,
-                       tan_component_in='et', cross_component_in='ex',
-                       tan_component_out='gt', cross_component_out='gx', table_name='profile',
-                       add_to_cluster=True, include_empty_bins=False, gal_ids_in_bins=False):
+def make_binned_profile(cluster, angsep_units, bin_units, bins=10, cosmo=None, tan_component_in='et', cross_component_in='ex', tan_component_out='gt', cross_component_out='gx', table_name='profile', add_to_cluster=True, include_empty_bins=False, gal_ids_in_bins=False):
     r"""Compute the shear or ellipticity profile of the cluster
 
     We assume that the cluster object contains information on the cross and

--- a/clmm/hybrid.py
+++ b/clmm/hybrid.py
@@ -2,6 +2,9 @@
 
 from astropy import units as u
 
+from .modeling import _convert_rad_to_mpc
+from .utils import compute_radial_averages, make_bins
+
 # function pointer instead of keywords as cosmo.sigma_crit_filter
 # compute tangential and cross in util and appears in calls for polaraveraging
 #

--- a/clmm/hybrid.py
+++ b/clmm/hybrid.py
@@ -1,0 +1,218 @@
+"""Functions requiring both data and model assumptions"""
+# function pointer instead of keywords as cosmo.sigma_crit_filter
+# compute tangential and cross in util and appears in calls for polaraveraging
+#
+# most polaraveraging already in utils
+#
+# check the cosmology again and again or ask for it to be input each time
+# GC has a cosmo, if it has a cosmo, must call from
+#
+# agnostic version in utils, can call directly if user specifies everything or call from 3 modules with our objects
+# base versions in util, dataoperations in
+
+def _convert_rad_to_mpc(dist1, redshift, cosmo, do_inverse=False):
+    r""" Convert between radians and Mpc using the small angle approximation
+    and :math:`d = D_A \theta`.
+
+    Parameters
+    ==========
+    dist1 : array_like
+        Input distances
+    redshift : float
+        Redshift used to convert between angular and physical units
+    cosmo : astropy.cosmology
+        Astropy cosmology object to compute angular diameter distance to
+        convert between physical and angular units
+    do_inverse : bool
+        If true, converts Mpc to radians
+
+    Returns
+    =======
+    dist2 : array_like
+        Converted distances
+    """
+    d_a = cosmo.angular_diameter_distance(redshift).to('Mpc').value
+    if do_inverse:
+        return dist1 / d_a
+    return dist1 * d_a
+
+def convert_units(dist1, unit1, unit2, redshift=None, cosmo=None):
+    """ Convenience wrapper to convert between a combination of angular and physical units.
+
+    Supported units: radians, degrees, arcmin, arcsec, Mpc, kpc, pc
+
+    To convert between angular and physical units you must provide both
+    a redshift and a cosmology object.
+
+    Parameters
+    ----------
+    dist1 : array_like
+        Input distances
+    unit1 : str
+        Unit for the input distances
+    unit2 : str
+        Unit for the output distances
+    redshift : float
+        Redshift used to convert between angular and physical units
+    cosmo : astropy.cosmology
+        Astropy cosmology object to compute angular diameter distance to
+        convert between physical and angular units
+
+    Returns
+    -------
+    dist2: array_like
+        Input distances converted to unit2
+    """
+    angular_bank = {"radians": u.rad, "degrees": u.deg, "arcmin": u.arcmin, "arcsec": u.arcsec}
+    physical_bank = {"pc": u.pc, "kpc": u.kpc, "Mpc": u.Mpc}
+    units_bank = {**angular_bank, **physical_bank}
+
+    # Some error checking
+    if unit1 not in units_bank:
+        raise ValueError(f"Input units ({unit1}) not supported")
+    if unit2 not in units_bank:
+        raise ValueError(f"Output units ({unit2}) not supported")
+
+    # Try automated astropy unit conversion
+    try:
+        return (dist1 * units_bank[unit1]).to(units_bank[unit2]).value
+
+    # Otherwise do manual conversion
+    except u.UnitConversionError:
+        # Make sure that we were passed a redshift and cosmology
+        if redshift is None or cosmo is None:
+            raise TypeError("Redshift and cosmology must be specified to convert units")
+
+        # Redshift must be greater than zero for this approx
+        if not redshift > 0.0:
+            raise ValueError("Redshift must be greater than 0.")
+
+        # Convert angular to physical
+        if (unit1 in angular_bank) and (unit2 in physical_bank):
+            dist1_rad = (dist1 * units_bank[unit1]).to(u.rad).value
+            dist1_mpc = _convert_rad_to_mpc(dist1_rad, redshift, cosmo, do_inverse=False)
+            return (dist1_mpc * u.Mpc).to(units_bank[unit2]).value
+
+        # Otherwise physical to angular
+        dist1_mpc = (dist1 * units_bank[unit1]).to(u.Mpc).value
+        dist1_rad = _convert_rad_to_mpc(dist1_mpc, redshift, cosmo, do_inverse=True)
+        return (dist1_rad * u.rad).to(units_bank[unit2]).value
+
+
+def make_binned_profile(cluster,
+                       angsep_units, bin_units, bins=10, cosmo=None,
+                       tan_component_in='et', cross_component_in='ex',
+                       tan_component_out='gt', cross_component_out='gx', table_name='profile',
+                       add_to_cluster=True, include_empty_bins=False, gal_ids_in_bins=False):
+    r"""Compute the shear or ellipticity profile of the cluster
+
+    We assume that the cluster object contains information on the cross and
+    tangential shears or ellipticities and angular separation of the source galaxies
+
+    This function can be called in two ways using an instance of GalaxyCluster
+
+    1. Pass an instance of GalaxyCluster into the function::
+
+        make_shear_profile(cluster, 'radians', 'radians')
+
+    2. Call it as a method of a GalaxyCluster instance::
+
+        cluster.make_shear_profile('radians', 'radians')
+
+    Parameters
+    ----------
+    cluster : GalaxyCluster
+        Instance of GalaxyCluster that contains the cross and tangential shears or ellipticities of
+        each source galaxy in its `galcat`
+    angsep_units : str
+        Units of the calculated separation of the source galaxies
+        Allowed Options = ["radians"]
+    bin_units : str
+        Units to use for the radial bins of the shear profile
+        Allowed Options = ["radians", deg", "arcmin", "arcsec", kpc", "Mpc"]
+    bins : array_like, optional
+        User defined bins to use for the shear profile. If a list is provided, use that as
+        the bin edges. If a scalar is provided, create that many equally spaced bins between
+        the minimum and maximum angular separations in bin_units. If nothing is provided,
+        default to 10 equally spaced bins.
+    cosmo: dict, optional
+        Cosmology parameters to convert angular separations to physical distances
+    tan_component_in: string, optional
+        Name of the column in the `galcat` astropy table of the `cluster` object that contains
+        the tangential component to be binned. Default: 'et'
+    tan_component_out: string, optional
+        Name of the column in the `profile` table of the `cluster` object that will contain
+        the binned profile of the tangential component. Default: 'gx'
+    cross_component_in: string, optional
+        Name of the column in the `galcat` astropy table of the `cluster` object that contains
+        the cross component to be binned. Default: 'ex'
+    cross_component_out: string, optional
+        Name of the column in the `profile` table of the `cluster` object that will contain
+        the  binned profile of the cross component. Default: 'gx'
+    add_to_cluster: bool, optional
+        Attach the profile to the cluster object as `cluster.profile`
+    include_empty_bins: bool, optional
+        Also include empty bins in the returned table
+    gal_ids_in_bins: bool, optional
+        Also include the list of galaxies ID belonging to each bin in the returned table
+
+    Returns
+    -------
+    profile : GCData
+        Output table containing the radius grid points, the tangential and cross shear profiles
+        on that grid, and the errors in the two shear profiles. The errors are defined as the
+        standard errors in each bin.
+
+    Notes
+    -----
+    This is an example of a place where the cosmology-dependence can be sequestered to another module.
+    """
+    if not all([t_ in cluster.galcat.columns for t_ in (tan_component_in, cross_component_in, 'theta')]):
+        raise TypeError('Shear or ellipticity information is missing!  Galaxy catalog must have tangential' +\
+                        'and cross shears (gt,gx) or ellipticities (et,ex). Run compute_tangential_and_cross_components first.')
+    if 'z' not in cluster.galcat.columns:
+        raise TypeError('Missing galaxy redshifts!')
+
+    # Check to see if we need to do a unit conversion
+    if angsep_units is not bin_units:
+        source_seps = convert_units(cluster.galcat['theta'], angsep_units, bin_units,
+                                    redshift=cluster.z, cosmo=cosmo)
+    else:
+        source_seps = cluster.galcat['theta']
+
+    # Make bins if they are not provided
+    if not hasattr(bins, '__len__'):
+        bins = make_bins(np.min(source_seps), np.max(source_seps), bins)
+
+    # Compute the binned averages and associated errors
+    r_avg, gt_avg, gt_err, nsrc, binnumber = compute_radial_averages(
+        source_seps, cluster.galcat[tan_component_in].data, xbins=bins, error_model='std/sqrt_n')
+    r_avg, gx_avg, gx_err, _, _ = compute_radial_averages(
+        source_seps, cluster.galcat[cross_component_in].data, xbins=bins, error_model='std/sqrt_n')
+    r_avg, z_avg, z_err, _, _ = compute_radial_averages(
+        source_seps, cluster.galcat['z'].data, xbins=bins, error_model='std/sqrt_n')
+
+    # Make out table
+    profile_table = GCData([bins[:-1], r_avg, bins[1:], gt_avg, gt_err, gx_avg, gx_err,
+                            z_avg, z_err, nsrc],
+                            names=('radius_min', 'radius', 'radius_max',
+                                   tan_component_out, tan_component_out+'_err',
+                                   cross_component_out, cross_component_out+'_err',
+                                   'z', 'z_err', 'n_src'),
+                            meta={'cosmo':cosmo, 'bin_units':bin_units}, # Add metadata
+                            )
+    # add galaxy IDs
+    if gal_ids_in_bins:
+        if 'id' not in cluster.galcat.columns:
+            raise TypeError('Missing galaxy IDs!')
+        profile_table['gal_id'] = [list(cluster.galcat['id'][binnumber==i+1])
+                                    for i in np.arange(len(r_avg))]
+
+    # return empty bins?
+    if not include_empty_bins:
+        profile_table = profile_table[profile_table['n_src'] > 1]
+
+    if add_to_cluster:
+        setattr(cluster, table_name, profile_table)
+
+    return profile_table

--- a/clmm/modeling.py
+++ b/clmm/modeling.py
@@ -1,12 +1,12 @@
 """Cosmology-dependent functions to model halo profiles"""
-import cluster_toolkit as ct
-import numpy as np
 from astropy import units
 from astropy.cosmology import LambdaCDM
-from .constants import Constants as const
-from .cluster_toolkit_patches import _patch_zevolution_cluster_toolkit_rho_m
+import cluster_toolkit as ct
+import numpy as np
 import warnings
 
+from .constants import Constants as const
+from .cluster_toolkit_patches import _patch_zevolution_cluster_toolkit_rho_m
 from .utils import _get_a_from_z, _get_z_from_a
 
 def cclify_astropy_cosmo(cosmoin):
@@ -74,23 +74,31 @@ def astropyify_ccl_cosmo(cosmoin):
     raise TypeError("Only astropy LambdaCDM objects or dicts can be converted to astropy.")
 
 
-def get_reduced_shear_from_convergence(shear, convergence):
-    """ Calculates reduced shear from shear and convergence
+def _convert_rad_to_mpc(dist1, redshift, cosmo, do_inverse=False):
+    r""" Convert between radians and Mpc using the small angle approximation
+    and :math:`d = D_A \theta`.
 
     Parameters
-    ----------
-    shear : array_like
-        Shear
-    convergence : array_like
-        Convergence
+    ==========
+    dist1 : array_like
+        Input distances
+    redshift : float
+        Redshift used to convert between angular and physical units
+    cosmo : astropy.cosmology
+        Astropy cosmology object to compute angular diameter distance to
+        convert between physical and angular units
+    do_inverse : bool
+        If true, converts Mpc to radians
 
-    Returns:
-    reduced_shear : array_like
-        Reduced shear
+    Returns
+    =======
+    dist2 : array_like
+        Converted distances
     """
-    shear, convergence = np.array(shear), np.array(convergence)
-    reduced_shear = shear / (1. - convergence)
-    return reduced_shear
+    d_a = cosmo.angular_diameter_distance(redshift).to('Mpc').value
+    if do_inverse:
+        return dist1 / d_a
+    return dist1 * d_a
 
 
 def get_3d_density(r3d, mdelta, cdelta, z_cl, cosmo, delta_mdef=200, halo_profile_model='nfw'):

--- a/clmm/utils.py
+++ b/clmm/utils.py
@@ -4,7 +4,6 @@ import numpy as np
 from scipy.stats import binned_statistic
 import warnings
 
-from .hybrid import _convert_rad_to_mpc
 
 def _get_a_from_z(redshift):
     """ Convert redshift to scale factor
@@ -172,6 +171,10 @@ def convert_shapes_to_epsilon(shape_1, shape_2, shape_definition='epsilon', kapp
         Epsilon ellipticity along principal axis (epsilon1)
     epsilon_2 : array_like
         Epsilon ellipticity along secondary axis (epsilon2)
+
+    Notes
+    -----
+    TODO: change name `epsilon`-->`ellipticities`
     """
 
     if shape_definition=='epsilon' or shape_definition=='reduced_shear':


### PR DESCRIPTION
I made a first stab at reorganizing where CLMM's cosmology-dependent and cosmology-independent functions live.  The initial plan was that there would be four modules, for all possible combinations of cosmology- and data- dependence.  Cosmology dependence is easy to identify -- does the function take a `cosmo` object? -- but it seems that data-dependence is really defined by whether the function needs a `GCData` object.  I reorganized where the functions live based on these definitions:
- `dataops.py` (formerly `polaraveraging.py`) for `GCData`-dependent functions
- `hybrid.py` for functions of `cosmo` and `GCData` objects
- `modeling.py` for `cosmo`-dependent functions
- `utils.py` for functions that don't touch either type of object

Note that `dataops.py` now contains only one function, and almost everything from `polaraveraging.py` ended up in `utils.py` (which I'd sort of like to rename).

In particular, I think this sets us up well for implementing @vitenti 's suggestion (#282) to build an object on top of these functions, but for both the `cosmo`-dependent and the `GCData`-dependent functions.

**This is a draft PR because the branch is intended to be a starting point for discussion!**  Please share your thoughts in the comments.