### PR TITLE
Add gha support

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python3-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools pandoc -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -42,6 +42,9 @@ jobs:
     - name: Run the unit tests
       run: |
         pytest-3 tests/ --ignore=cluster_toolkit/tests --cov=clmm/
+    - name: Install Sphinx prereq
+      run: |
+        sudo pip3 install sphinx_rtd_theme
     - name: Run the docs
       run: |
         make -C docs/ html

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -48,7 +48,8 @@ jobs:
     - name: Run the docs
       run: |
         make -C docs/ html
-    - name: Coveralls Finished
-      uses: AndreMiras/coveralls-python-action@develop
-      with:
-        parallel-finished: true
+    - name: Coveralls
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        coveralls

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-sphinx-rtd-theme python3-nbconvert python3-jupyter-client jupyter-client  jupyter-nbconvert pandoc -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-sphinx-rtd-theme python3-nbconvert python3-jupyter-client jupyter-client jupyter-nbconvert sphinx-common pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-sphinx-rtd-theme python3-nbconvert python3-jupyter-client jupyter-client pandoc -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-sphinx-rtd-theme python3-nbconvert python3-jupyter-client jupyter-client  jupyter-nbconvert pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -19,12 +19,13 @@ jobs:
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git
         cd cluster_toolkit
-        python setup.py install
+        sudo python setup.py install
     - name: Install CCL from source
       run: |
+        pwd
         git clone https://github.com/LSSTDESC/CCL
         cd CCL
-        python setup.py install
+        sudo python setup.py install
         cd -
     - name: Install NumCosmo from source
       run: |

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -13,12 +13,34 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install prereq
+    - name: Install prereq using apt
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev  \
+        gobject-introspection python-gobject gfortran libmpfr-dev \
+        libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev     \
+        gir1.2-glib-2.0 libgirepository1.0-dev python3-gi         \
+        python-gi -y
+    - name: Install cluster_toolkit from source
       run: |
-        sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python-gi -y
-        git clone https://github.com/tmcclintock/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
-        git clone https://github.com/LSSTDESC/CCL ; cd CCL ; python setup.py install ; cd -
-        wget https://github.com/NumCosmo/NumCosmo/releases/download/v0.15.2/numcosmo-0.15.2.tar.gz && tar xf numcosmo-0.15.2.tar.gz && cd numcosmo-0.15.2 && ./configure --prefix=/usr && make -j4 && sudo make install && cd -
+        git clone https://github.com/tmcclintock/cluster_toolkit.git
+        cd cluster_toolkit
+        python setup.py install
+    - name: Install CCL from source
+      run: |
+        git clone https://github.com/LSSTDESC/CCL
+        cd CCL
+        python setup.py install
+        cd -
+    - name: Install NumCosmo from source
+      run: |
+        wget https://github.com/NumCosmo/NumCosmo/releases/download/v0.15.2/numcosmo-0.15.2.tar.gz
+        tar xf numcosmo-0.15.2.tar.gz
+        cd numcosmo-0.15.2
+        ./configure --prefix=/usr
+        make -j4
+        sudo make install
+        cd -
+    - name: Install prereq using pip
+      run: |        
         pip install pycairo==1.19.1
         pip install pygobject
         export MPLBACKEND="agg"

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -36,16 +36,16 @@ jobs:
     - name: Install prereq using pip
       run: |        
         python3 numcosmo-0.15.2/examples/example_simple.py
-        pip install -r requirements.txt
+        pip3 install -r requirements.txt
     - name: Install the package
       run: python setup.py install
     - name: Install docs prereq
       run: |
         sudo apt-get install pandoc -y
-        pip install ipykernel
+        pip3 install ipykernel
         python -m ipykernel install --user --name python3 --display-name python3
-        pip install sphinx==2.1.2 sphinx_rtd_theme nbconvert jupyter_client
-        pip install coveralls pytest-cov
+        pip3 install sphinx==2.1.2 sphinx_rtd_theme nbconvert jupyter_client
+        pip3 install coveralls pytest-cov
     - name: Run the unit tests
       run: py.test tests/ --ignore=cluster_toolkit/tests --cov=clmm/
     - name: Run the docs

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -2,7 +2,7 @@ name: Build and Check
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, add_gha_support ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -1,10 +1,6 @@
 name: Build and Check
 
-on:
-  push:
-    branches: [ master, add_gha_support ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build-gcc-ubuntu:

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Run the unit tests
       run: |
         pip3 install pytest
-        py.test-3 tests/ --ignore=cluster_toolkit/tests --cov=clmm/
+        pytest tests/ --ignore=cluster_toolkit/tests --cov=clmm/
     - name: Run the docs
       run: |
         sphinx-quickstart -a "travis" -p clmm -v 0.0.1 --ext-autodoc -q

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -41,7 +41,7 @@ jobs:
       run: sudo python3 setup.py install
     - name: Run the unit tests
       run: |
-        pytest tests/ --ignore=cluster_toolkit/tests --cov=clmm/
+        pytest-3 tests/ --ignore=cluster_toolkit/tests --cov=clmm/
     - name: Run the docs
       run: |
         sphinx-quickstart -a "travis" -p clmm -v 0.0.1 --ext-autodoc -q

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -44,8 +44,6 @@ jobs:
         pytest-3 tests/ --ignore=cluster_toolkit/tests --cov=clmm/
     - name: Run the docs
       run: |
-        sudo pip3 install sphinxcontrib-apidoc
-        sphinx-quickstart -a "travis" -p clmm -v 0.0.1 --ext-autodoc -q
         make -C docs/ html
     - name: Coveralls
       uses: coverallsapp/github-action@master

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install prereq
       run: |
-        sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio3-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python-gi -y
+        sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python-gi -y
         git clone https://github.com/tmcclintock/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
         git clone https://github.com/LSSTDESC/CCL ; cd CCL ; python setup.py install ; cd -
         wget https://github.com/NumCosmo/NumCosmo/releases/download/v0.15.2/numcosmo-0.15.2.tar.gz && tar xf numcosmo-0.15.2.tar.gz && cd numcosmo-0.15.2 && ./configure --prefix=/usr && make -j4 && sudo make install && cd -

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-sphinx-rtd-theme python3-nbconvert python3-jupyter-client pandoc -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-sphinx-rtd-theme python3-nbconvert python3-jupyter-client jupyter-client pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -52,4 +52,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        sudo pip3 install coveralls
         coveralls

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx pandoc -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-nbconvert pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -46,7 +46,9 @@ jobs:
         pip3 install sphinx==2.1.2 sphinx_rtd_theme nbconvert jupyter_client
         pip3 install coveralls pytest-cov
     - name: Run the unit tests
-      run: py.test-3 tests/ --ignore=cluster_toolkit/tests --cov=clmm/
+      run: |
+        pip3 install pytest
+        py.test tests/ --ignore=cluster_toolkit/tests --cov=clmm/
     - name: Run the docs
       run: |
         sphinx-quickstart -a "travis" -p clmm -v 0.0.1 --ext-autodoc -q

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,11 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev  \
-        gobject-introspection python-gobject gfortran libmpfr-dev \
-        libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev     \
-        gir1.2-glib-2.0 libgirepository1.0-dev python3-gi         \
-        python-gi -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python-gi -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools pandoc -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python3-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git
@@ -24,7 +24,7 @@ jobs:
       run: |
         git clone https://github.com/LSSTDESC/CCL
         cd CCL
-        sudo python setup.py install
+        sudo python3 setup.py install
     - name: Install NumCosmo from source
       run: |
         wget https://github.com/NumCosmo/NumCosmo/releases/download/v0.15.2/numcosmo-0.15.2.tar.gz

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-nbconvert pandoc -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-sphinx-rtd-theme python3-nbconvert python3-jupyter-client pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -13,8 +13,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install sudo package
-      run: apt update && apt install sudo git
     - name: Install prereq using apt
       run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-sphinx-rtd-theme python3-nbconvert python3-jupyter-client jupyter-client jupyter-nbconvert sphinx-common pandoc -y
     - name: Install cluster_toolkit from source

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -46,9 +46,12 @@ jobs:
         pip3 install sphinx==2.1.2 sphinx_rtd_theme nbconvert jupyter_client
         pip3 install coveralls pytest-cov
     - name: Run the unit tests
-      run: py.test tests/ --ignore=cluster_toolkit/tests --cov=clmm/
+      run: py.test-3 tests/ --ignore=cluster_toolkit/tests --cov=clmm/
     - name: Run the docs
       run: |
         sphinx-quickstart -a "travis" -p clmm -v 0.0.1 --ext-autodoc -q
         make -C docs/ html
-
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install sudo package
+      run: apt update && apt install sudo git
     - name: Install prereq using apt
       run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-sphinx-rtd-theme python3-nbconvert python3-jupyter-client jupyter-client jupyter-nbconvert sphinx-common pandoc -y
     - name: Install cluster_toolkit from source

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -36,18 +36,17 @@ jobs:
     - name: Install prereq using pip
       run: |        
         python3 numcosmo-0.15.2/examples/example_simple.py
-        pip3 install -r requirements.txt
+        sudo pip3 install -r requirements.txt
     - name: Install the package
       run: sudo python3 setup.py install
     - name: Install docs prereq
       run: |
-        pip3 install ipykernel
+        sudo pip3 install ipykernel
         python3 -m ipykernel install --user --name python3 --display-name python3
-        pip3 install sphinx==2.1.2 sphinx_rtd_theme nbconvert jupyter_client
-        pip3 install coveralls pytest-cov
+        sudo pip3 install sphinx==2.1.2 sphinx_rtd_theme nbconvert jupyter_client
+        sudo pip3 install coveralls pytest-cov
     - name: Run the unit tests
       run: |
-        pip3 install pytest
         pytest tests/ --ignore=cluster_toolkit/tests --cov=clmm/
     - name: Run the docs
       run: |

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools pandoc -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git
@@ -39,12 +39,6 @@ jobs:
         sudo pip3 install -r requirements.txt
     - name: Install the package
       run: sudo python3 setup.py install
-    - name: Install docs prereq
-      run: |
-        sudo pip3 install ipykernel
-        python3 -m ipykernel install --user --name python3 --display-name python3
-        sudo pip3 install sphinx==2.1.2 sphinx_rtd_theme nbconvert jupyter_client
-        sudo pip3 install coveralls pytest-cov
     - name: Run the unit tests
       run: |
         pytest tests/ --ignore=cluster_toolkit/tests --cov=clmm/

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest pandoc -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git
@@ -48,7 +48,7 @@ jobs:
     - name: Run the unit tests
       run: |
         pip3 install pytest
-        py.test tests/ --ignore=cluster_toolkit/tests --cov=clmm/
+        py.test-3 tests/ --ignore=cluster_toolkit/tests --cov=clmm/
     - name: Run the docs
       run: |
         sphinx-quickstart -a "travis" -p clmm -v 0.0.1 --ext-autodoc -q

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-sphinx-rtd-theme python3-nbconvert python3-jupyter-client jupyter-client jupyter-nbconvert sphinx-common pandoc -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-sphinx-rtd-theme python3-nbconvert python3-jupyter-client jupyter-client jupyter-nbconvert sphinx-common python3-sphinxcontrib.apidoc pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -1,0 +1,43 @@
+name: Build and Check
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-gcc-ubuntu:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install prereq
+      run: |
+        sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio3-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python-gi -y
+        git clone https://github.com/tmcclintock/cluster_toolkit.git ; cd cluster_toolkit ; python setup.py install ; cd -
+        git clone https://github.com/LSSTDESC/CCL ; cd CCL ; python setup.py install ; cd -
+        wget https://github.com/NumCosmo/NumCosmo/releases/download/v0.15.2/numcosmo-0.15.2.tar.gz && tar xf numcosmo-0.15.2.tar.gz && cd numcosmo-0.15.2 && ./configure --prefix=/usr && make -j4 && sudo make install && cd -
+        pip install pycairo==1.19.1
+        pip install pygobject
+        export MPLBACKEND="agg"
+        pip install matplotlib
+        python3 numcosmo-0.15.2/examples/example_simple.py
+        pip install -r requirements.txt
+    - name: Install the package
+      run: python setup.py install
+    - name: Install docs prereq
+      run: |
+        sudo apt-get install pandoc -y
+        pip install ipykernel
+        python -m ipykernel install --user --name python3 --display-name python3
+        pip install sphinx==2.1.2 sphinx_rtd_theme nbconvert jupyter_client
+        pip install coveralls pytest-cov
+    - name: Run the unit tests
+      run: py.test tests/ --ignore=cluster_toolkit/tests --cov=clmm/
+    - name: Run the docs
+      run: |
+        sphinx-quickstart -a "travis" -p clmm -v 0.0.1 --ext-autodoc -q
+        make -C docs/ html
+

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Run the docs
       run: |
         make -C docs/ html
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
+    - name: Coveralls Finished
+      uses: AndreMiras/coveralls-python-action@develop
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        parallel-finished: true

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools pandoc -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -44,7 +44,7 @@ jobs:
         pytest-3 tests/ --ignore=cluster_toolkit/tests --cov=clmm/
     - name: Install Sphinx prereq
       run: |
-        sudo pip3 install sphinx_rtd_theme
+        sudo pip3 install sphinx_rtd_theme -U
     - name: Run the docs
       run: |
         make -C docs/ html

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python-gi python-numpy python3-matplotlib pandoc -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git
         cd cluster_toolkit
-        sudo python setup.py install
+        sudo python3 setup.py install
     - name: Install CCL from source
       run: |
         git clone https://github.com/LSSTDESC/CCL

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python-gi python-numpy python3-matplotlib -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python-gi python-numpy python3-matplotlib pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git
@@ -38,12 +38,11 @@ jobs:
         python3 numcosmo-0.15.2/examples/example_simple.py
         pip3 install -r requirements.txt
     - name: Install the package
-      run: python setup.py install
+      run: sudo python3 setup.py install
     - name: Install docs prereq
       run: |
-        sudo apt-get install pandoc -y
         pip3 install ipykernel
-        python -m ipykernel install --user --name python3 --display-name python3
+        python3 -m ipykernel install --user --name python3 --display-name python3
         pip3 install sphinx==2.1.2 sphinx_rtd_theme nbconvert jupyter_client
         pip3 install coveralls pytest-cov
     - name: Run the unit tests

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-sphinx-rtd-theme python3-nbconvert python3-jupyter-client jupyter-client jupyter-nbconvert sphinx-common python3-sphinxcontrib.apidoc pandoc -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python3-numpy python3-matplotlib python3-setuptools python3-pytest-cov python3-sphinx python3-sphinx-rtd-theme python3-nbconvert python3-jupyter-client jupyter-client jupyter-nbconvert sphinx-common pandoc -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git
@@ -44,6 +44,7 @@ jobs:
         pytest-3 tests/ --ignore=cluster_toolkit/tests --cov=clmm/
     - name: Run the docs
       run: |
+        sudo pip3 install sphinxcontrib-apidoc
         sphinx-quickstart -a "travis" -p clmm -v 0.0.1 --ext-autodoc -q
         make -C docs/ html
     - name: Coveralls

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python-gi -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python-gi python-numpy -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install prereq using apt
-      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python-gi python-numpy -y
+      run: sudo apt-get install libgsl0-dev swig3.0 libfftw3-dev gobject-introspection python-gobject gfortran libmpfr-dev libhdf5-dev liblapack-dev libnlopt-dev libcfitsio-dev gir1.2-glib-2.0 libgirepository1.0-dev python3-gi python-gi python-numpy python3-matplotlib -y
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git
@@ -22,11 +22,9 @@ jobs:
         sudo python setup.py install
     - name: Install CCL from source
       run: |
-        pwd
         git clone https://github.com/LSSTDESC/CCL
         cd CCL
         sudo python setup.py install
-        cd -
     - name: Install NumCosmo from source
       run: |
         wget https://github.com/NumCosmo/NumCosmo/releases/download/v0.15.2/numcosmo-0.15.2.tar.gz
@@ -35,13 +33,8 @@ jobs:
         ./configure --prefix=/usr
         make -j4
         sudo make install
-        cd -
     - name: Install prereq using pip
       run: |        
-        pip install pycairo==1.19.1
-        pip install pygobject
-        export MPLBACKEND="agg"
-        pip install matplotlib
         python3 numcosmo-0.15.2/examples/example_simple.py
         pip install -r requirements.txt
     - name: Install the package

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ script:
   - py.test tests/ --ignore=cluster_toolkit/tests --cov=clmm/
 
   # Run the docs:
-  - sphinx-quickstart -a "travis" -p clmm -v 0.0.1 --ext-autodoc -q
   - make -C docs/ html
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # CLMM
 [![Build Status](https://travis-ci.org/LSSTDESC/CLMM.svg?branch=master)](https://travis-ci.org/LSSTDESC/CLMM) 
+[![Build and Check](https://github.com/LSSTDESC/CLMM/workflows/Build%20and%20Check/badge.svg)](https://github.com/LSSTDESC/CLMM/actions?query=workflow%3A%22Build+and+Check%22)
 [![Coverage Status](https://coveralls.io/repos/github/LSSTDESC/CLMM/badge.svg)](https://coveralls.io/github/LSSTDESC/CLMM)
 
 The LSST-DESC Cluster Lensing Mass Modeling (CLMM) code is a Python library for performing galaxy cluster weak lensing analyses.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,7 +7,9 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = CLMM
 SOURCEDIR     = .
 BUILDDIR      = _build
-RM			  = rm -rf
+RM	      = rm -rf
+SPHINXAPIDOC  = sphinx-apidoc
+MODULEDIR     = ../clmm
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -16,7 +18,7 @@ help:
 .PHONY: help Makefile
 
 .PHONY: html
-html: 
+html: sphinx-apidoc
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(0) -W
 
 .PHONY: clean
@@ -27,3 +29,6 @@ clean:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -W
+
+sphinx-apidoc:
+	@$(SPHINXAPIDOC) --separate --no-toc -f -M -o api $(MODULEDIR)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,6 @@ release = version
 
 # -- General configuration ------------------------------------------------
 extensions = ['sphinx.ext.autodoc',
-              'sphinxcontrib.apidoc',
               'sphinx.ext.autosummary',
               'sphinx.ext.viewcode',
               'sphinx.ext.napoleon',
@@ -99,16 +98,16 @@ napoleon_use_ivar = True
 # -- Options for Autodoc--------------------------------------------------
 # Autodoc collects docstrings and builds API pages
 
-def run_apidoc(_):
-    from sphinxcontrib.apidoc import main as apidoc_main
-    cur_dir = os.path.normpath(os.path.dirname(__file__))
-    output_path = os.path.join(cur_dir, 'api')
-    modules = os.path.normpath(os.path.join(cur_dir, "../clmm"))
-    paramlist = ['--separate', '--no-toc', '-f', '-M', '-o', output_path, modules]
-    apidoc_main(paramlist)
+#def run_apidoc(_):
+#    from sphinxcontrib.apidoc import main as apidoc_main
+#    cur_dir = os.path.normpath(os.path.dirname(__file__))
+#    output_path = os.path.join(cur_dir, 'api')
+#    modules = os.path.normpath(os.path.join(cur_dir, "../clmm"))
+#    paramlist = ['--separate', '--no-toc', '-f', '-M', '-o', output_path, modules]
+#    apidoc_main(paramlist)
 
-def setup(app):
-    app.connect('builder-inited', run_apidoc)
+#def setup(app):
+#    app.connect('builder-inited', run_apidoc)
 
 
 # -- Load from the config file -------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ release = version
 
 # -- General configuration ------------------------------------------------
 extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.apidoc',
+              'sphinxcontrib.apidoc',
               'sphinx.ext.autosummary',
               'sphinx.ext.viewcode',
               'sphinx.ext.napoleon',
@@ -98,7 +98,7 @@ napoleon_use_ivar = True
 # Autodoc collects docstrings and builds API pages
 
 def run_apidoc(_):
-    from sphinx.ext.apidoc import main as apidoc_main
+    from sphinxcontrib.apidoc import main as apidoc_main
     cur_dir = os.path.normpath(os.path.dirname(__file__))
     output_path = os.path.join(cur_dir, 'api')
     modules = os.path.normpath(os.path.join(cur_dir, "../clmm"))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,8 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.githubpages',
               'IPython.sphinxext.ipython_console_highlighting']
 
+apidoc_module_dir = '../clmm'
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 source_suffix = ['.rst', '.md']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ release = version
 
 # -- General configuration ------------------------------------------------
 extensions = ['sphinx.ext.autodoc',
+              'sphinx.ext.apidoc',
               'sphinx.ext.autosummary',
               'sphinx.ext.viewcode',
               'sphinx.ext.napoleon',


### PR DESCRIPTION
Adding support for GitHub actions, once this is stable and reviewed Travis-ci support can be dropped. The documentation generating code (had to be) was updated and works with the latest sphinx version available. 

- [ ] Check if the documentation is being built correctly.
- [ ] Check if coverage upload is correct.
- [ ] Check if it is necessary to change branch configuration in order to run GHA in every branch.