### PR TITLE
Issue/341/fix replacement bug

### DIFF
--- a/examples/support/mock_data.py
+++ b/examples/support/mock_data.py
@@ -7,6 +7,7 @@ from astropy import units
 from clmm.modeling import predict_tangential_shear, predict_convergence
 from clmm.utils import convert_units, compute_lensed_ellipticity
 
+import pdb
 def generate_galaxy_catalog(cluster_m, cluster_z, cluster_c, cosmo, zsrc, Delta_SO=200, massdef='mean',halo_profile_model='nfw', zsrc_min=None,
                             zsrc_max=7., field_size=8., shapenoise=None, photoz_sigma_unscaled=None, nretry=5, ngals=None, ngal_density=None):
     """Generates a mock dataset of sheared background galaxies.
@@ -140,8 +141,8 @@ def generate_galaxy_catalog(cluster_m, cluster_z, cluster_c, cosmo, zsrc, Delta_
         nbad, badids = _find_aphysical_galaxies(galaxy_catalog, zsrc_min)
         if nbad < 1:
             break
-        replacements = _generate_galaxy_catalog(ngals=nbad, **params)
-        galaxy_catalog[badids] = replacements
+        replacements = _generate_galaxy_catalog(ngals=nbad+1, **params)
+        galaxy_catalog[badids] = replacements[:-1]
 
     # Final check to see if there are bad galaxies left
     nbad, _ = _find_aphysical_galaxies(galaxy_catalog, zsrc_min)

--- a/examples/support/mock_data.py
+++ b/examples/support/mock_data.py
@@ -141,6 +141,9 @@ def generate_galaxy_catalog(cluster_m, cluster_z, cluster_c, cosmo, zsrc, Delta_
         nbad, badids = _find_aphysical_galaxies(galaxy_catalog, zsrc_min)
         if nbad < 1:
             break
+        # In case nbad=1, replacements does not produce a table with the right
+        # shape. To avoid the problem, always draw an extra galaxy and remove it
+        # when assigning the results to galaxy_catalog
         replacements = _generate_galaxy_catalog(ngals=nbad+1, **params)
         galaxy_catalog[badids] = replacements[:-1]
 

--- a/examples/support/mock_data.py
+++ b/examples/support/mock_data.py
@@ -7,7 +7,6 @@ from astropy import units
 from clmm.modeling import predict_tangential_shear, predict_convergence
 from clmm.utils import convert_units, compute_lensed_ellipticity
 
-import pdb
 def generate_galaxy_catalog(cluster_m, cluster_z, cluster_c, cosmo, zsrc, Delta_SO=200, massdef='mean',halo_profile_model='nfw', zsrc_min=None,
                             zsrc_max=7., field_size=8., shapenoise=None, photoz_sigma_unscaled=None, nretry=5, ngals=None, ngal_density=None):
     """Generates a mock dataset of sheared background galaxies.

--- a/examples/support/mock_data.py
+++ b/examples/support/mock_data.py
@@ -342,8 +342,15 @@ def _compute_photoz_pdfs(galaxy_catalog, photoz_sigma_unscaled):
         zbins = np.arange(zmin, zmax, 0.03)
         pzbins_grid.append(zbins)
         pzpdf_grid.append(np.exp(-0.5*((zbins-row['z'])/row['pzsigma'])**2)/np.sqrt(2*np.pi*row['pzsigma']**2))
-    galaxy_catalog['pzbins'] = pzbins_grid
-    galaxy_catalog['pzpdf'] = pzpdf_grid
+    # quick fix to make sure the shape of galaxy_catalog['pzpdf'][i] is (1,)
+    # it add n_extra extra zero values to the last galaxy and removes it from the out table
+    n_extra = len(pzbins_grid[-2])
+    pzbins_grid[-1] = np.append(pzbins_grid[-1], np.zeros(n_extra))
+    pzpdf_grid[-1] = np.append(pzpdf_grid[-1], np.zeros(n_extra))
+    galaxy_catalog['pzbins'] = np.array(pzbins_grid, dtype=object)
+    galaxy_catalog['pzpdf'] = np.array(pzpdf_grid, dtype=object)
+    galaxy_catalog['pzbins'][-1] = pzbins_grid[-1][:-n_extra]
+    galaxy_catalog['pzpdf'][-1] = pzpdf_grid[-1][:-n_extra]
 
     return galaxy_catalog
 


### PR DESCRIPTION
In `generate_mock_data`, the replacement of "bad" galaxies is failing when there's only one galaxy to replace. In that case, the shape of the column to add into `galaxy_catalog` does no correspond to the shape of the existing column in `galaxy_catalog`. A quick fix was to draw `nbad + 1` galaxies and use only `nbad` of them for the replacement. Thanks @m-aguena for the suggestion :)