### PR TITLE
Add computations without flat sky

### DIFF
--- a/clmm/dataops/__init__.py
+++ b/clmm/dataops/__init__.py
@@ -110,7 +110,7 @@ def compute_tangential_and_cross_components(
         angsep, phi = _compute_lensing_angles_flatsky(ra_lens, dec_lens,
                                                       ra_source_, dec_source_)
     elif geometry=='curve':
-        angsep, phi = _compute_lensing_angles_ap(ra_lens, dec_lens,
+        angsep, phi = _compute_lensing_angles_astropy(ra_lens, dec_lens,
                                                       ra_source_, dec_source_)
     else:
         raise NotImplementedError(f"Sky geometry {geometry} is not currently supported")
@@ -184,7 +184,7 @@ def _compute_lensing_angles_flatsky(ra_lens, dec_lens, ra_source_list, dec_sourc
     return angsep, phi
 
 
-def _compute_lensing_angles_ap(ra_lens, dec_lens, ra_source_list, dec_source_list):
+def _compute_lensing_angles_astropy(ra_lens, dec_lens, ra_source_list, dec_source_list):
     r"""Compute the angular separation between the lens and the source and the azimuthal
     angle from the lens to the source in radians.
 

--- a/clmm/dataops/__init__.py
+++ b/clmm/dataops/__init__.py
@@ -2,6 +2,8 @@
 import math
 import warnings
 import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy import units as u
 from .. gcdata import GCData
 from . .utils import compute_radial_averages, make_bins, convert_units, arguments_consistency
 from .. theory import compute_critical_surface_density
@@ -9,7 +11,7 @@ from .. theory import compute_critical_surface_density
 
 def compute_tangential_and_cross_components(
                 ra_lens, dec_lens, ra_source, dec_source,
-                shear1, shear2, geometry='flat',
+                shear1, shear2, geometry='curve',
                 is_deltasigma=False, cosmo=None,
                 z_lens=None, z_source=None, sigma_c=None):
     r"""Computes tangential- and cross- components for shear or ellipticity
@@ -61,20 +63,20 @@ def compute_tangential_and_cross_components(
     Parameters
     ----------
     ra_lens: float
-        Right ascension of the lensing cluster
+        Right ascension of the lensing cluster in degrees
     dec_lens: float
-        Declination of the lensing cluster
+        Declination of the lensing cluster in degrees
     ra_source: array
-        Right ascensions of each source galaxy
+        Right ascensions of each source galaxy in degrees
     dec_source: array
-        Declinations of each source galaxy
+        Declinations of each source galaxy in degrees
     shear1: array
         The measured shear (or reduced shear or ellipticity) of the source galaxies
     shear2: array
         The measured shear (or reduced shear or ellipticity) of the source galaxies
     geometry: str, optional
         Sky geometry to compute angular separation.
-        Flat is currently the only supported option.
+        Options are curve (uses astropy) or flat.
     is_deltasigma: bool
         If `True`, the tangential and cross components returned are multiplied by Sigma_crit. Results in units of :math:`M_\odot\ Mpc^{-2}`
     cosmo: clmm.Cosmology, optional
@@ -107,6 +109,9 @@ def compute_tangential_and_cross_components(
     if geometry == 'flat':
         angsep, phi = _compute_lensing_angles_flatsky(ra_lens, dec_lens,
                                                       ra_source_, dec_source_)
+    elif geometry=='curve':
+        angsep, phi = _compute_lensing_angles_ap(ra_lens, dec_lens,
+                                                      ra_source_, dec_source_)
     else:
         raise NotImplementedError(f"Sky geometry {geometry} is not currently supported")
     # Compute the tangential and cross shears
@@ -124,7 +129,6 @@ def compute_tangential_and_cross_components(
     return angsep, tangential_comp, cross_comp
 
 
-
 def _compute_lensing_angles_flatsky(ra_lens, dec_lens, ra_source_list, dec_source_list):
     r"""Compute the angular separation between the lens and the source and the azimuthal
     angle from the lens to the source in radians.
@@ -137,6 +141,24 @@ def _compute_lensing_angles_flatsky(ra_lens, dec_lens, ra_source_list, dec_sourc
         \tan\phi = \frac{\delta_s-\delta_l}{\left(\alpha_l-\alpha_s\right)\cos(\delta_l)}
 
     For extended descriptions of parameters, see `compute_shear()` documentation.
+
+    Parameters
+    ----------
+    ra_lens: float
+        Right ascension of the lensing cluster in degrees
+    dec_lens: float
+        Declination of the lensing cluster in degrees
+    ra_source_list: array
+        Right ascensions of each source galaxy in degrees
+    dec_source_list: array
+        Declinations of each source galaxy in degrees
+
+    Returns
+    -------
+    angsep: array
+        Angular separation between the lens and the source in radians
+    phi: array
+        Azimuthal angle from the lens to the source in radians
     """
     if not -360. <= ra_lens <= 360.:
         raise ValueError(f"ra = {ra_lens} of lens if out of domain")
@@ -159,6 +181,46 @@ def _compute_lensing_angles_flatsky(ra_lens, dec_lens, ra_source_list, dec_sourc
     phi[angsep==0.0] = 0.0
     if np.any(angsep > np.pi/180.):
         warnings.warn("Using the flat-sky approximation with separations >1 deg may be inaccurate")
+    return angsep, phi
+
+
+def _compute_lensing_angles_ap(ra_lens, dec_lens, ra_source_list, dec_source_list):
+    r"""Compute the angular separation between the lens and the source and the azimuthal
+    angle from the lens to the source in radians.
+
+    Parameters
+    ----------
+    ra_lens: float
+        Right ascension of the lensing cluster in degrees
+    dec_lens: float
+        Declination of the lensing cluster in degrees
+    ra_source_list: array
+        Right ascensions of each source galaxy in degrees
+    dec_source_list: array
+        Declinations of each source galaxy in degrees
+
+    Returns
+    -------
+    angsep: array
+        Angular separation between the lens and the source in radians
+    phi: array
+        Azimuthal angle from the lens to the source in radians
+    """
+    if not -360. <= ra_lens <= 360.:
+        raise ValueError(f"ra = {ra_lens} of lens if out of domain")
+    if not -90. <= dec_lens <= 90.:
+        raise ValueError(f"dec = {dec_lens} of lens if out of domain")
+    if not all(-360. <= x_ <= 360. for x_ in ra_source_list):
+        raise ValueError("Cluster has an invalid ra in source catalog")
+    if not all(-90. <= x_ <= 90 for x_ in dec_source_list):
+        raise ValueError("Cluster has an invalid dec in the source catalog")
+    sk_lens = SkyCoord(ra_lens*u.deg, dec_lens*u.deg, frame='icrs')
+    sk_src = SkyCoord(ra_source_list*u.deg, dec_source_list*u.deg, frame='icrs')
+    angsep, phi = sk_lens.separation(sk_src).rad, sk_lens.position_angle(sk_src).rad
+    # Transformations for phi to have same orientation as _compute_lensing_angles_flatsky
+    phi += 0.5*np.pi
+    phi[phi>np.pi] -= 2*np.pi
+    phi[angsep==0] = 0
     return angsep, phi
 
 

--- a/clmm/galaxycluster.py
+++ b/clmm/galaxycluster.py
@@ -125,7 +125,7 @@ class GalaxyCluster():
     def compute_tangential_and_cross_components(self,
                       shape_component1='e1', shape_component2='e2',
                       tan_component='et', cross_component='ex',
-                      geometry='flat', is_deltasigma=False, cosmo=None,
+                      geometry='curve', is_deltasigma=False, cosmo=None,
                       add=True):
         r"""Adds a tangential- and cross- components for shear or ellipticity to self
 
@@ -158,7 +158,7 @@ class GalaxyCluster():
             Default: `ex`
         geometry: str, optional
             Sky geometry to compute angular separation.
-            Flat is currently the only supported option.
+            Options are curve (uses astropy) or flat.
         is_deltasigma: bool
             If `True`, the tangential and cross components returned are multiplied by Sigma_crit. Results in units of :math:`M_\odot\ Mpc^{-2}`
         cosmo: astropy cosmology object

--- a/examples/Flat_sky_limitations.ipynb
+++ b/examples/Flat_sky_limitations.ipynb
@@ -1,0 +1,601 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# API demonstration for paper of v1.0\n",
+    "\n",
+    "_the LSST-DESC CLMM team_\n",
+    "\n",
+    "\n",
+    "Here we demonstrate how to use `clmm` to estimate a WL halo mass from observations of a galaxy cluster when source galaxies follow a given distribution (The LSST DESC Science Requirements Document - arXiv:1809.01669,  implemented in `clmm`). It uses several functionalities of the support `mock_data` module to produce mock datasets.\n",
+    "\n",
+    "- Setting things up, with the proper imports.\n",
+    "- Computing the binned reduced tangential shear profile, for the 2 datasets, using logarithmic binning.\n",
+    "- Setting up a model accounting for the redshift distribution.\n",
+    "- Perform a simple fit using `scipy.optimize.curve_fit` included in `clmm` and visualize the results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we import some standard packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "plt.rcParams['font.family'] = ['gothambook','gotham','gotham-book','serif']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from clmm.dataops import _compute_lensing_angles_flatsky as clmm_flat\n",
+    "from clmm.dataops import _compute_lensing_angles_ap as clmm_full"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ra1, dec1 = 0, 0\n",
+    "t = np.linspace(0, np.pi*2, 100)[:-1]\n",
+    "ra2 = ra1+np.cos(t)\n",
+    "dec2 = dec1+np.sin(t)\n",
+    "\n",
+    "flat_vals = clmm_flat(ra1, dec1, ra2, dec2)\n",
+    "full_vals = clmm_full(ra1, dec1, ra2, dec2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f, axes = plt.subplots(2, sharex=True)\n",
+    "\n",
+    "axes[0].plot(full_vals[1], flat_vals[0]-full_vals[0])\n",
+    "axes[0].set_ylabel('$\\\\theta$ [Flat-Curve]')\n",
+    "\n",
+    "axes[1].plot(full_vals[1], flat_vals[1]-full_vals[1])\n",
+    "axes[1].set_xlabel('Azimuthal angle')\n",
+    "axes[1].set_ylabel('$\\phi$ [Flat-Curve]')\n",
+    "\n",
+    "for ax in axes:\n",
+    "    ax.set_xticks(np.arange(-1, 1.01, 0.5)*np.pi)\n",
+    "    ax.xaxis.grid(True, which='major', lw=.5)\n",
+    "    ax.yaxis.grid(True, which='major', lw=.5)\n",
+    "    ax.xaxis.grid(True, which='minor', lw=.1)\n",
+    "    ax.yaxis.grid(True, which='minor', lw=.1)\n",
+    "    \n",
+    "axes[1].set_xticklabels(['$-\\pi$', '$-\\\\frac{\\pi}{2}$', '$0$', '$\\\\frac{\\pi}{2}$', '$\\pi$'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generating mock data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`clmm` has a support code to generate a mock catalog given a input cosmology and cluster parameters. We will use this to generate a data sample to be used in this example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from clmm import Cosmology\n",
+    "import clmm.support.mock_data as mock"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(14) # For reproducibility\n",
+    "\n",
+    "# Set cosmology of mock data\n",
+    "cosmo = Cosmology(H0=70.0, Omega_dm0=0.27-0.045, Omega_b0=0.045, Omega_k0=0.0)\n",
+    "\n",
+    "# Cluster info\n",
+    "cluster_m = 1.e15 # Cluster mass - ($M200_m$) [Msun]\n",
+    "concentration = 4  # Cluster concentration\n",
+    "cluster_z = 0.3 # Cluster redshift\n",
+    "cluster_ra = 0. # Cluster Ra in deg\n",
+    "cluster_dec = 0. # Cluster Dec in deg\n",
+    "\n",
+    "# Catalog info\n",
+    "field_size = 10 # i.e. 10 x 10 Mpc field at the cluster redshift, cluster in the center\n",
+    "\n",
+    "# Make mock galaxies\n",
+    "mock_galaxies = mock.generate_galaxy_catalog(\n",
+    "    cluster_m=cluster_m, cluster_z=cluster_z, cluster_c=concentration, # Cluster data\n",
+    "    cosmo=cosmo, # Cosmology object\n",
+    "    zsrc='desc_srd', # Galaxy redshift distribution, \n",
+    "    zsrc_min=0.4, # Minimum redshift of the galaxies\n",
+    "    shapenoise=0.05, # Gaussian shape noise to the galaxy shapes\n",
+    "    photoz_sigma_unscaled=0.05, # Photo-z errors to source redshifts\n",
+    "    field_size=field_size,\n",
+    "    ngal_density=20 # number of gal/arcmin2 for z in [0, infty]\n",
+    ")['ra', 'dec', 'e1', 'e2', 'z', 'ztrue', 'pzbins', 'pzpdf', 'id']\n",
+    "print(f'Catalog table with the columns: {\", \".join(mock_galaxies.colnames)}')\n",
+    "\n",
+    "ngals_init = len(mock_galaxies)\n",
+    "print(f'Initial number of galaxies: {ngals_init:,}')\n",
+    "\n",
+    "# Keeping only galaxies with \"measured\" redshift greater than cluster redshift\n",
+    "mock_galaxies = mock_galaxies[(mock_galaxies['z']>cluster_z)]\n",
+    "ngals_good = len(mock_galaxies)\n",
+    "\n",
+    "if ngals_good < ngals_init:\n",
+    "    print(f'Number of excluded galaxies (with photoz < cluster_z): {ngals_init-ngals_good:,}')\n",
+    "    # reset galaxy id for later use\n",
+    "    mock_galaxies['id'] = np.arange(ngals_good)\n",
+    "\n",
+    "# Check final density\n",
+    "from clmm.utils import convert_units\n",
+    "field_size_arcmin = convert_units(field_size, 'Mpc', 'arcmin', redshift=cluster_z, cosmo=cosmo)\n",
+    "print(f'Background galaxy density = {ngals_good/field_size_arcmin**2:.2f} gal/arcmin2\\n')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Shear values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import clmm\n",
+    "import copy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a GalaxyCluster\n",
+    "cluster_flat = clmm.GalaxyCluster(\"Name of cluster\", cluster_ra, cluster_dec,\n",
+    "                                   cluster_z, mock_galaxies)\n",
+    "cluster = clmm.GalaxyCluster(\"Name of cluster\", cluster_ra, cluster_dec,\n",
+    "                                   cluster_z, copy.deepcopy(mock_galaxies))\n",
+    "\n",
+    "# Convert elipticities into shears for the members\n",
+    "cluster_flat.compute_tangential_and_cross_components(geometry=\"flat\")\n",
+    "cluster.compute_tangential_and_cross_components(geometry=\"curve\")\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def colorp(x, y, c, **kwargs):\n",
+    "    isort = np.argsort(c)\n",
+    "    return plt.scatter(x[isort], y[isort], c=c[isort], **kwargs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc = colorp(mock_galaxies['ra'], mock_galaxies['dec'], \n",
+    "            c=abs(cluster_flat.galcat['et']-cluster.galcat['et']), s=1)\n",
+    "plt.colorbar(sc, label='$\\Delta g_t$')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc = colorp(mock_galaxies['ra'], mock_galaxies['dec'], \n",
+    "            c=abs(cluster_flat.galcat['ex']-cluster.galcat['ex']), s=1)\n",
+    "plt.colorbar(sc, label='$\\Delta g_x$')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Profile values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import clmm.dataops as da\n",
+    "# Measure profile and add profile table to the cluster\n",
+    "cluster_flat.make_radial_profile(bins=da.make_bins(0.1, field_size/2., 25, method='evenlog10width'),\n",
+    "                            bin_units=\"Mpc\",\n",
+    "                            cosmo=cosmo,\n",
+    "                            include_empty_bins=False,\n",
+    "                            gal_ids_in_bins=True,\n",
+    "                           )\n",
+    "cluster.make_radial_profile(bins=da.make_bins(0.1, field_size/2., 25, method='evenlog10width'),\n",
+    "                            bin_units=\"Mpc\",\n",
+    "                            cosmo=cosmo,\n",
+    "                            include_empty_bins=False,\n",
+    "                            gal_ids_in_bins=True,\n",
+    "                           )\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#from paper_formating import prep_plot\n",
+    "#prep_plot(figsize=(9, 9))\n",
+    "f, axes = plt.subplots(2, sharex=True)\n",
+    "\n",
+    "errorbar_kwargs = dict(linestyle='', marker='o',\n",
+    "    markersize=1, elinewidth=.5, capthick=.5)\n",
+    "\n",
+    "axes[0].errorbar(cluster.profile['radius'], cluster.profile['gt'],\n",
+    "             cluster.profile['gt_err'], c='k', label='curve', **errorbar_kwargs)\n",
+    "axes[0].errorbar(cluster_flat.profile['radius'], cluster_flat.profile['gt'],\n",
+    "             cluster_flat.profile['gt_err'], c='r', label='flat', **errorbar_kwargs)\n",
+    "axes[1].errorbar(cluster.profile['radius'],\n",
+    "                (cluster_flat.profile['gt']-cluster.profile['gt']),\n",
+    "                 cluster.profile['gt_err'], **errorbar_kwargs)\n",
+    "axes[1].set_xlabel('r [Mpc]', fontsize = 10)\n",
+    "axes[0].set_ylabel(r'$g_t$', fontsize = 10)\n",
+    "axes[1].set_ylabel(r'$\\Delta g_t$', fontsize = 10)\n",
+    "axes[1].set_xscale('log')\n",
+    "axes[0].set_yscale('log')\n",
+    "axes[0].legend()\n",
+    "\n",
+    "for ax in axes:\n",
+    "    ax.xaxis.grid(True, which='major', lw=.5)\n",
+    "    ax.yaxis.grid(True, which='major', lw=.5)\n",
+    "    ax.xaxis.grid(True, which='minor', lw=.1)\n",
+    "    ax.yaxis.grid(True, which='minor', lw=.1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Theoretical predictions\n",
+    "\n",
+    "We consider 3 models:\n",
+    "1. One model where all sources are considered at the same redshift\n",
+    "2. One model using the overall source redshift distribution to predict the reduced tangential shear\n",
+    "3. A more accurate model, relying on the fact that we have access to the individual redshifts of the sources, where the average reduced tangential shear is averaged independently in each bin, accounting for the acutal population of sources in each bin.\n",
+    "\n",
+    "All models rely on `clmm.predict_reduced_tangential_shear` to make a prediction that accounts for the redshift distribution of the galaxies in each radial bin:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Model considering all sources located at the average redshift\n",
+    "\\begin{equation}\n",
+    "     g_{t,i}^{\\rm{avg(z)}} = g_t(R_i, \\langle z \\rangle)\\;,\n",
+    " \\label{eq:wrong_gt_model}\n",
+    " \\end{equation} "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def predict_reduced_tangential_shear_mean_z(profile, logm):\n",
+    "    return clmm.compute_reduced_tangential_shear(\n",
+    "            r_proj=profile['radius'], # Radial component of the profile\n",
+    "            mdelta=10**logm, # Mass of the cluster [M_sun]\n",
+    "            cdelta=4, # Concentration of the cluster\n",
+    "            z_cluster=cluster_z, # Redshift of the cluster\n",
+    "            z_source=np.mean(cluster.galcat['z']), # Mean value of source galaxies redshift\n",
+    "            cosmo=cosmo,\n",
+    "            delta_mdef=200,\n",
+    "            halo_profile_model='nfw'\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Model relying on the overall redshift distribution of the sources N(z), not using individual redshift information (eq. (6) from Applegate et al. 2014, MNRAS, 439, 48) \n",
+    "\\begin{equation}\n",
+    "     g_{t,i}^{N(z)} = \\frac{\\langle\\beta_s\\rangle \\gamma_t(R_i, z\\rightarrow\\infty)}{1-\\frac{\\langle\\beta_s^2\\rangle}{\\langle\\beta_s\\rangle}\\kappa(R_i, z\\rightarrow\\infty)}\n",
+    "     \\label{eq:approx_model}\n",
+    " \\end{equation}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z_inf = 1000\n",
+    "dl_inf = cosmo.eval_da_z1z2(cluster_z, z_inf)\n",
+    "d_inf = cosmo.eval_da(z_inf)\n",
+    "\n",
+    "def betas(z):\n",
+    "    dls = cosmo.eval_da_z1z2(cluster_z, z)\n",
+    "    ds = cosmo.eval_da(z)\n",
+    "    return dls * d_inf / (ds * dl_inf)\n",
+    "\n",
+    "def predict_reduced_tangential_shear_approx(profile, logm):\n",
+    "\n",
+    "    bs_mean = np.mean(betas(cluster.galcat['z'])) \n",
+    "    bs2_mean = np.mean(betas(cluster.galcat['z'])**2)\n",
+    "\n",
+    "    gamma_t_inf = clmm.compute_tangential_shear(\n",
+    "            r_proj=profile['radius'], # Radial component of the profile\n",
+    "            mdelta=10**logm, # Mass of the cluster [M_sun]\n",
+    "            cdelta=4, # Concentration of the cluster\n",
+    "            z_cluster=cluster_z, # Redshift of the cluster\n",
+    "            z_source=z_inf, # Redshift value at infinity\n",
+    "            cosmo=cosmo,\n",
+    "            delta_mdef=200,\n",
+    "            halo_profile_model='nfw')\n",
+    "    convergence_inf = clmm.compute_convergence(\n",
+    "            r_proj=profile['radius'], # Radial component of the profile\n",
+    "            mdelta=10**logm, # Mass of the cluster [M_sun]\n",
+    "            cdelta=4, # Concentration of the cluster\n",
+    "            z_cluster=cluster_z, # Redshift of the cluster\n",
+    "            z_source=z_inf, # Redshift value at infinity\n",
+    "            cosmo=cosmo,\n",
+    "            delta_mdef=200,\n",
+    "            halo_profile_model='nfw')\n",
+    "        \n",
+    "    return bs_mean*gamma_t_inf/(1-(bs2_mean/bs_mean)*convergence_inf)       "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Model using individual redshift and radial information, to compute the averaged shear in each radial bin, based on the galaxies actually present in that bin.\n",
+    "\\begin{equation}\n",
+    "    g_{t,i}^{z, R} = \\frac{1}{N_i}\\sum_{{\\rm gal\\,}j\\in {\\rm bin\\,}i} g_t(R_j, z_j)\n",
+    "    \\label{eq:exact_model}\n",
+    " \\end{equation}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster.galcat['theta_mpc'] = convert_units(cluster.galcat['theta'], 'radians', 'mpc',cluster.z, cosmo)\n",
+    "\n",
+    "def predict_reduced_tangential_shear_exact(profile, logm):\n",
+    "    return np.array([np.mean(\n",
+    "        clmm.compute_reduced_tangential_shear(\n",
+    "            # Radial component of each source galaxy inside the radial bin\n",
+    "            r_proj=cluster.galcat[radial_bin['gal_id']]['theta_mpc'],\n",
+    "            mdelta=10**logm, # Mass of the cluster [M_sun]\n",
+    "            cdelta=4, # Concentration of the cluster\n",
+    "            z_cluster=cluster_z, # Redshift of the cluster\n",
+    "            # Redshift value of each source galaxy inside the radial bin\n",
+    "            z_source=cluster.galcat[radial_bin['gal_id']]['z'],\n",
+    "            cosmo=cosmo,\n",
+    "            delta_mdef=200,\n",
+    "            halo_profile_model='nfw'\n",
+    "        )) for radial_bin in profile])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mass fitting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We estimate the best-fit mass using `scipy.optimize.curve_fit`. The choice of fitting $\\log M$ instead of $M$ lowers the range of pre-defined fitting bounds from several order of magnitude for the mass to unity. From the associated error $\\sigma_{\\log M}$ we calculate the error to mass as $\\sigma_M = M_{fit}\\ln(10)\\sigma_{\\log M}$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### First, identify bins with sufficient galaxy statistics to be kept for the fit\n",
+    "For small samples, error bars should not be computed using the simple error on the mean approach available so far in CLMM)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_for_fit = cluster.profile[cluster.profile['n_src'] > 5]\n",
+    "data_for_fit_flat = cluster_flat.profile[cluster_flat.profile['n_src'] > 5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Perform the fits\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from clmm.support.sampler import fitters\n",
+    "def fit_mass(predict_function, data_for_fit=data_for_fit):\n",
+    "    popt, pcov = fitters['curve_fit'](predict_function,\n",
+    "        data_for_fit, \n",
+    "        data_for_fit['gt'], \n",
+    "        data_for_fit['gt_err'], bounds=[10.,17.])\n",
+    "    logm, logm_err = popt[0], np.sqrt(pcov[0][0])\n",
+    "    return {'logm':logm, 'logm_err':logm_err,\n",
+    "            'm': 10**logm, 'm_err': (10**logm)*logm_err*np.log(10)}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fit_mean_z = fit_mass(predict_reduced_tangential_shear_mean_z)\n",
+    "fit_approx = fit_mass(predict_reduced_tangential_shear_approx)\n",
+    "fit_exact = fit_mass(predict_reduced_tangential_shear_exact)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fit_mean_z_flat = fit_mass(predict_reduced_tangential_shear_mean_z, data_for_fit_flat)\n",
+    "fit_approx_flat = fit_mass(predict_reduced_tangential_shear_approx, data_for_fit_flat)\n",
+    "fit_exact_flat = fit_mass(predict_reduced_tangential_shear_exact, data_for_fit_flat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'Input mass = {cluster_m:.2e} Msun\\n')\n",
+    "print('Curve sky')\n",
+    "print(f'Best fit mass for average redshift               = {fit_mean_z[\"m\"]:.3e} +/- {fit_mean_z[\"m_err\"]:.3e} Msun')\n",
+    "print(f'Best fit mass for N(z) model                     = {fit_approx[\"m\"]:.3e} +/- {fit_approx[\"m_err\"]:.3e} Msun')\n",
+    "print(f'Best fit mass for individual redshift and radius = {fit_exact[\"m\"]:.3e} +/- {fit_exact[\"m_err\"]:.3e} Msun')\n",
+    "print()\n",
+    "print('Flat sky')\n",
+    "print(f'Best fit mass for average redshift               = {fit_mean_z_flat[\"m\"]:.3e} +/- {fit_mean_z_flat[\"m_err\"]:.3e} Msun')\n",
+    "print(f'Best fit mass for N(z) model                     = {fit_approx_flat[\"m\"]:.3e} +/- {fit_approx_flat[\"m_err\"]:.3e} Msun')\n",
+    "print(f'Best fit mass for individual redshift and radius = {fit_exact_flat[\"m\"]:.3e} +/- {fit_exact_flat[\"m_err\"]:.3e} Msun')\n",
+    "print()\n",
+    "print('Difference (Curve-Flat)')\n",
+    "print(f'Best fit mass for average redshift               = {fit_mean_z_flat[\"m\"]-fit_mean_z[\"m\"]:.3e} Msun')\n",
+    "print(f'Best fit mass for N(z) model                     = {fit_approx_flat[\"m\"]-fit_approx[\"m\"]:.3e} Msun')\n",
+    "print(f'Best fit mass for individual redshift and radius = {fit_exact_flat[\"m\"]-fit_exact[\"m\"]:.3e} Msun')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reduced $\\chi$2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_predicted_shear(predict_function, fit_values):\n",
+    "    gt_est = predict_function(data_for_fit, fit_values['logm'])\n",
+    "    gt_est_err = [predict_function(data_for_fit, fit_values['logm']+i*fit_values['logm_err'])\n",
+    "                          for i in (-3, 3)]\n",
+    "    return gt_est, gt_est_err\n",
+    "def chi2(predict_function, fit_values):\n",
+    "    gt_mean_z, gt_err_mean_z =  get_predicted_shear(predict_function, fit_values)\n",
+    "    return np.sum((gt_mean_z-data_for_fit['gt'])**2/(data_for_fit['gt_err'])**2)/(len(data_for_fit)-1)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Curve sky')\n",
+    "print(f'Reduced chi2 (mean z model) = {chi2(predict_reduced_tangential_shear_mean_z, fit_mean_z)}')\n",
+    "print(f'Reduced chi2 (N(z) model) = {chi2(predict_reduced_tangential_shear_approx, fit_approx)}')\n",
+    "print(f'Reduced chi2 (individual (R,z) model) = {chi2(predict_reduced_tangential_shear_exact, fit_exact)}')\n",
+    "print()\n",
+    "print('Flat sky')\n",
+    "print(f'Reduced chi2 (mean z model) = {chi2(predict_reduced_tangential_shear_mean_z, fit_mean_z_flat)}')\n",
+    "print(f'Reduced chi2 (N(z) model) = {chi2(predict_reduced_tangential_shear_approx, fit_approx_flat)}')\n",
+    "print(f'Reduced chi2 (individual (R,z) model) = {chi2(predict_reduced_tangential_shear_exact, fit_exact_flat)}')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda-clmmenv",
+   "language": "python",
+   "name": "conda-clmmenv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/test_dataops.py
+++ b/tests/test_dataops.py
@@ -61,23 +61,25 @@ def test_compute_lensing_angles_flatsky():
     ra_l, dec_l = 161., 65.
     ra_s, dec_s = np.array([-355., 355.]), np.array([-85., 85.])
 
-    # Test domains on inputs
-    testing.assert_raises(ValueError, da._compute_lensing_angles_flatsky,
-                          -365., dec_l, ra_s, dec_s)
-    testing.assert_raises(ValueError, da._compute_lensing_angles_flatsky,
-                          365., dec_l, ra_s, dec_s)
-    testing.assert_raises(ValueError, da._compute_lensing_angles_flatsky,
-                          ra_l, 95., ra_s, dec_s)
-    testing.assert_raises(ValueError, da._compute_lensing_angles_flatsky,
-                          ra_l, -95., ra_s, dec_s)
-    testing.assert_raises(ValueError, da._compute_lensing_angles_flatsky,
-                          ra_l, dec_l, ra_s-10., dec_s)
-    testing.assert_raises(ValueError, da._compute_lensing_angles_flatsky,
-                          ra_l, dec_l, ra_s+10., dec_s)
-    testing.assert_raises(ValueError, da._compute_lensing_angles_flatsky,
-                          ra_l, dec_l, ra_s, dec_s-10.)
-    testing.assert_raises(ValueError, da._compute_lensing_angles_flatsky,
-                          ra_l, dec_l, ra_s, dec_s+10.)
+    for compute_lensing_angles in (da._compute_lensing_angles_flatsky,
+                                   da._compute_lensing_angles_astropy):
+        # Test domains on inputs
+        testing.assert_raises(ValueError, compute_lensing_angles,
+                              -365., dec_l, ra_s, dec_s)
+        testing.assert_raises(ValueError, compute_lensing_angles,
+                              365., dec_l, ra_s, dec_s)
+        testing.assert_raises(ValueError, compute_lensing_angles,
+                              ra_l, 95., ra_s, dec_s)
+        testing.assert_raises(ValueError, compute_lensing_angles,
+                              ra_l, -95., ra_s, dec_s)
+        testing.assert_raises(ValueError, compute_lensing_angles,
+                              ra_l, dec_l, ra_s-10., dec_s)
+        testing.assert_raises(ValueError, compute_lensing_angles,
+                              ra_l, dec_l, ra_s+10., dec_s)
+        testing.assert_raises(ValueError, compute_lensing_angles,
+                              ra_l, dec_l, ra_s, dec_s-10.)
+        testing.assert_raises(ValueError, compute_lensing_angles,
+                              ra_l, dec_l, ra_s, dec_s+10.)
 
     # Ensure that we throw a warning with >1 deg separation
     testing.assert_warns(UserWarning, da._compute_lensing_angles_flatsky,
@@ -126,107 +128,123 @@ def test_compute_tangential_and_cross_components(modeling_data):
     # Input values
     reltol = modeling_data['dataops_reltol']
     ra_lens, dec_lens, z_lens = 120., 42., 0.5
-    ra_source = np.array([120.1, 119.9])
-    dec_source = np.array([41.9, 42.2])
-    z_source = np.array([1.,2.])
-    shear1 = np.array([0.2, 0.4])
-    shear2 = np.array([0.3, 0.5])
+    gals = GCData({
+        'ra': np.array([120.1, 119.9]),
+        'dec': np.array([41.9, 42.2]),
+        'id': np.array([1, 2]),
+        'e1': np.array([0.2, 0.4]),
+        'e2': np.array([0.3, 0.5]),
+        'z': np.array([1.,2.]),
+        })
     # Correct values
-    expected_angsep = np.array([0.0021745039090962414, 0.0037238407383072053])
-    expected_cross_shear = np.array([0.2780316984090899, 0.6398792901134982])
-    expected_tangential_shear = np.array([-0.22956126563459447, -0.02354769805831558])
-    # DeltaSigma expected values for clmm.Cosmology(H0=67.66, Omega_dm0=0.262, Omega_b0=0.049)
-    expected_cross_DS = np.array([8.58093068e+14, 1.33131522e+15]) #[1224.3326297393244, 1899.6061989365176])*0.7*1.0e12*1.0002565513832675
-    expected_tangential_DS = np.array([-7.08498103e+14, -4.89926917e+13]) #[-1010.889584349285, -69.9059242788237])*0.7*1.0e12*1.0002565513832675
+    expected_flat = {
+        'angsep': np.array([0.0021745039090962414, 0.0037238407383072053]),
+        'cross_shear': np.array([0.2780316984090899, 0.6398792901134982]),
+        'tangential_shear': np.array([-0.22956126563459447, -0.02354769805831558]),
+        # DeltaSigma expected values for clmm.Cosmology(H0=67.66, Omega_dm0=0.262, Omega_b0=0.049)
+        'cross_DS': np.array([8.58093068e+14, 1.33131522e+15]), #[1224.3326297393244, 1899.6061989365176])*0.7*1.0e12*1.0002565513832675
+        'tangential_DS': np.array([-7.08498103e+14, -4.89926917e+13]), #[-1010.889584349285, -69.9059242788237])*0.7*1.0e12*1.0002565513832675
+    }
+    expected_curve = {# <<TO BE ADDED IN THE FUTURE>>
+        'angsep': np.array([]),
+        'cross_shear': np.array([]),
+        'tangential_shear': np.array([]),
+        'cross_DS': np.array([]),
+        'tangential_DS': np.array([]),
+    }
+    # Geometries to test
+    geo_tests = [('flat', expected_flat), ('curve', expected_curve)]
+    geo_tests = geo_tests[:1] # <<DELETE THIS LINE WHEN CURVE VALUES ADDED>>
     # test incosnsitent data
     testing.assert_raises(TypeError, da.compute_tangential_and_cross_components,
-        ra_lens=ra_lens, dec_lens=dec_lens, ra_source=ra_source[0], dec_source=dec_source,
-        shear1=shear1, shear2=shear2)
+        ra_lens=ra_lens, dec_lens=dec_lens, ra_source=gals['ra'][0], dec_source=gals['dec'],
+        shear1=gals['e1'], shear2=gals['e2'])
     testing.assert_raises(TypeError, da.compute_tangential_and_cross_components,
-        ra_lens=ra_lens, dec_lens=dec_lens, ra_source=ra_source[:1], dec_source=dec_source,
-        shear1=shear1, shear2=shear2)
+        ra_lens=ra_lens, dec_lens=dec_lens, ra_source=gals['ra'][:1], dec_source=gals['dec'],
+        shear1=gals['e1'], shear2=gals['e2'])
     # test not implemented geometry
     testing.assert_raises(NotImplementedError, da.compute_tangential_and_cross_components,
-        ra_lens=ra_lens, dec_lens=dec_lens, ra_source=ra_source, dec_source=dec_source,
-        shear1=shear1, shear2=shear2, geometry='something crazy')
-    # Pass arrays directly into function
-    angsep, tshear, xshear = da.compute_tangential_and_cross_components(ra_lens=ra_lens, dec_lens=dec_lens,
-                                              ra_source=ra_source, dec_source=dec_source,
-                                              shear1=shear1, shear2=shear2)
-    testing.assert_allclose(angsep, expected_angsep, **TOLERANCE,
+        ra_lens=ra_lens, dec_lens=dec_lens, ra_source=gals['ra'], dec_source=gals['dec'],
+        shear1=gals['e1'], shear2=gals['e2'], geometry='something crazy')
+    for geometry, expected in geo_tests:
+        # Pass arrays directly into function
+        angsep, tshear, xshear = da.compute_tangential_and_cross_components(ra_lens=ra_lens, dec_lens=dec_lens,
+                                              ra_source=gals['ra'], dec_source=gals['dec'],
+                                              shear1=gals['e1'], shear2=gals['e2'], geometry=geometry)
+        testing.assert_allclose(angsep, expected['angsep'], **TOLERANCE,
                             err_msg="Angular Separation not correct when passing lists")
-    testing.assert_allclose(tshear, expected_tangential_shear, **TOLERANCE,
+        testing.assert_allclose(tshear, expected['tangential_shear'], **TOLERANCE,
                             err_msg="Tangential Shear not correct when passing lists")
-    testing.assert_allclose(xshear, expected_cross_shear, **TOLERANCE,
+        testing.assert_allclose(xshear, expected['cross_shear'], **TOLERANCE,
                             err_msg="Cross Shear not correct when passing lists")
-    # Pass LISTS into function
-    angsep, tshear, xshear = da.compute_tangential_and_cross_components(ra_lens=ra_lens, dec_lens=dec_lens,
-                                ra_source=list(ra_source), dec_source=list(dec_source),
-                                shear1=list(shear1), shear2=list(shear2))
-    testing.assert_allclose(angsep, expected_angsep, **TOLERANCE,
-                            err_msg="Angular Separation not correct when passing lists")
-    testing.assert_allclose(tshear, expected_tangential_shear, **TOLERANCE,
-                            err_msg="Tangential Shear not correct when passing lists")
-    testing.assert_allclose(xshear, expected_cross_shear, **TOLERANCE,
-                            err_msg="Cross Shear not correct when passing lists")
+        # Pass LISTS into function
+        angsep, tshear, xshear = da.compute_tangential_and_cross_components(ra_lens=ra_lens, dec_lens=dec_lens,
+                                    ra_source=list(gals['ra']), dec_source=list(gals['dec']),
+                                    shear1=list(gals['e1']), shear2=list(gals['e2']), geometry=geometry)
+        testing.assert_allclose(angsep, expected['angsep'], **TOLERANCE,
+                                err_msg="Angular Separation not correct when passing lists")
+        testing.assert_allclose(tshear, expected['tangential_shear'], **TOLERANCE,
+                                err_msg="Tangential Shear not correct when passing lists")
+        testing.assert_allclose(xshear, expected['cross_shear'], **TOLERANCE,
+                                err_msg="Cross Shear not correct when passing lists")
     # Use the cluster method
     cluster = clmm.GalaxyCluster(unique_id='blah', ra=ra_lens, dec=dec_lens, z=z_lens,
-                                 galcat=GCData([ra_source, dec_source, shear1, shear2],
-                                              names=('ra', 'dec', 'e1', 'e2')))
+                                 galcat=gals['ra', 'dec', 'e1', 'e2'])
     # Test error with bad name/missing column
     testing.assert_raises(TypeError, cluster.compute_tangential_and_cross_components,
                           shape_component1='crazy name')
     # Test output
-    angsep3, tshear3, xshear3 = cluster.compute_tangential_and_cross_components()
-    testing.assert_allclose(angsep3, expected_angsep, **TOLERANCE,
-                            err_msg="Angular Separation not correct when using cluster method")
-    testing.assert_allclose(tshear3, expected_tangential_shear, **TOLERANCE,
-                            err_msg="Tangential Shear not correct when using cluster method")
-    testing.assert_allclose(xshear3, expected_cross_shear, **TOLERANCE,
-                            err_msg="Cross Shear not correct when using cluster method")
+    for geometry, expected in geo_tests:
+        angsep3, tshear3, xshear3 = cluster.compute_tangential_and_cross_components(geometry=geometry)
+        testing.assert_allclose(angsep3, expected['angsep'], **TOLERANCE,
+                                err_msg="Angular Separation not correct when using cluster method")
+        testing.assert_allclose(tshear3, expected['tangential_shear'], **TOLERANCE,
+                                err_msg="Tangential Shear not correct when using cluster method")
+        testing.assert_allclose(xshear3, expected['cross_shear'], **TOLERANCE,
+                                err_msg="Cross Shear not correct when using cluster method")
     # Check behaviour for the deltasigma option.
     cosmo = clmm.Cosmology(H0=70.0, Omega_dm0=0.275, Omega_b0=0.025)
     # test missing info for is_deltasigma=True
     testing.assert_raises(TypeError, da.compute_tangential_and_cross_components,
-        ra_lens=ra_lens, dec_lens=dec_lens, ra_source=ra_source, dec_source=dec_source,
-        shear1=shear1, shear2=shear2, is_deltasigma=True, cosmo=None, z_lens=z_lens, z_source=z_source)
+        ra_lens=ra_lens, dec_lens=dec_lens, ra_source=gals['ra'], dec_source=gals['dec'],
+        shear1=gals['e1'], shear2=gals['e2'], is_deltasigma=True, cosmo=None, z_lens=z_lens, z_source=gals['z'])
     testing.assert_raises(TypeError, da.compute_tangential_and_cross_components,
-        ra_lens=ra_lens, dec_lens=dec_lens, ra_source=ra_source, dec_source=dec_source,
-        shear1=shear1, shear2=shear2, is_deltasigma=True, cosmo=cosmo, z_lens=None, z_source=z_source)
+        ra_lens=ra_lens, dec_lens=dec_lens, ra_source=gals['ra'], dec_source=gals['dec'],
+        shear1=gals['e1'], shear2=gals['e2'], is_deltasigma=True, cosmo=cosmo, z_lens=None, z_source=gals['z'])
     testing.assert_raises(TypeError, da.compute_tangential_and_cross_components,
-        ra_lens=ra_lens, dec_lens=dec_lens, ra_source=ra_source, dec_source=dec_source,
-        shear1=shear1, shear2=shear2, is_deltasigma=True, cosmo=cosmo, z_lens=z_lens, z_source=None)
+        ra_lens=ra_lens, dec_lens=dec_lens, ra_source=gals['ra'], dec_source=gals['dec'],
+        shear1=gals['e1'], shear2=gals['e2'], is_deltasigma=True, cosmo=cosmo, z_lens=z_lens, z_source=None)
     # check values for DeltaSigma
-    angsep_DS, tDS, xDS = da.compute_tangential_and_cross_components(
-        ra_lens=ra_lens, dec_lens=dec_lens,
-        ra_source=ra_source, dec_source=dec_source,
-        shear1=shear1, shear2=shear2, is_deltasigma=True,
-        cosmo=cosmo, z_lens=z_lens, z_source=z_source)
-    testing.assert_allclose(angsep_DS, expected_angsep, reltol,
-                            err_msg="Angular Separation not correct")
-    testing.assert_allclose(tDS, expected_tangential_DS, reltol,
-                            err_msg="Tangential Shear not correct")
-    testing.assert_allclose(xDS, expected_cross_DS, reltol,
-                            err_msg="Cross Shear not correct")
+    for geometry, expected in geo_tests:
+        angsep_DS, tDS, xDS = da.compute_tangential_and_cross_components(
+            ra_lens=ra_lens, dec_lens=dec_lens,
+            ra_source=gals['ra'], dec_source=gals['dec'],
+            shear1=gals['e1'], shear2=gals['e2'], is_deltasigma=True,
+            cosmo=cosmo, z_lens=z_lens, z_source=gals['z'], geometry=geometry)
+        testing.assert_allclose(angsep_DS, expected['angsep'], reltol,
+                                err_msg="Angular Separation not correct")
+        testing.assert_allclose(tDS, expected['tangential_DS'], reltol,
+                                err_msg="Tangential Shear not correct")
+        testing.assert_allclose(xDS, expected['cross_DS'], reltol,
+                                err_msg="Cross Shear not correct")
     # Tests with the cluster object
     # cluster object missing source redshift, and function call missing cosmology
     cluster = clmm.GalaxyCluster(unique_id='blah', ra=ra_lens, dec=dec_lens, z=z_lens,
-                                 galcat=GCData([ra_source, dec_source, shear1, shear2],
-                                              names=('ra', 'dec', 'e1', 'e2')))
+                                 galcat=gals['ra', 'dec', 'e1', 'e2'])
     testing.assert_raises(TypeError, cluster.compute_tangential_and_cross_components, is_deltasigma=True)
     # cluster object OK but function call missing cosmology
     cluster = clmm.GalaxyCluster(unique_id='blah', ra=ra_lens, dec=dec_lens, z=z_lens,
-                                 galcat=GCData([ra_source, dec_source, shear1, shear2, z_source],
-                                               names=('ra', 'dec', 'e1', 'e2','z')))
+                                 galcat=gals['ra', 'dec', 'e1', 'e2','z'])
     testing.assert_raises(TypeError, cluster.compute_tangential_and_cross_components, is_deltasigma=True)
     # check values for DeltaSigma
-    angsep_DS, tDS, xDS = cluster.compute_tangential_and_cross_components(cosmo=cosmo, is_deltasigma=True)
-    testing.assert_allclose(angsep_DS, expected_angsep, reltol,
-                            err_msg="Angular Separation not correct when using cluster method")
-    testing.assert_allclose(tDS, expected_tangential_DS, reltol,
-                            err_msg="Tangential Shear not correct when using cluster method")
-    testing.assert_allclose(xDS, expected_cross_DS, reltol,
-                            err_msg="Cross Shear not correct when using cluster method")
+    for geometry, expected in geo_tests:
+        angsep_DS, tDS, xDS = cluster.compute_tangential_and_cross_components(cosmo=cosmo, is_deltasigma=True, geometry=geometry)
+        testing.assert_allclose(angsep_DS, expected['angsep'], reltol,
+                                err_msg="Angular Separation not correct when using cluster method")
+        testing.assert_allclose(tDS, expected['tangential_DS'], reltol,
+                                err_msg="Tangential Shear not correct when using cluster method")
+        testing.assert_allclose(xDS, expected['cross_DS'], reltol,
+                                err_msg="Cross Shear not correct when using cluster method")
 
 
 def _test_profile_table_output(profile, expected_rmin, expected_radius, expected_rmax,
@@ -253,116 +271,130 @@ def _test_profile_table_output(profile, expected_rmin, expected_radius, expected
 def test_make_radial_profiles():
     # Set up a cluster object and compute cross and tangential shears
     ra_lens, dec_lens, z_lens = 120., 42., 0.5
-    ra_source = np.array([120.1, 119.9, 119.9])
-    dec_source = np.array([41.9, 42.2, 42.2])
-    id_source = np.array([1, 2, 3])
-    shear1 = np.array([0.2, 0.4, 0.4])
-    shear2 = np.array([0.3, 0.5, 0.5])
-    z_sources = np.ones(3)
+    gals = GCData({
+        'ra': np.array([120.1, 119.9, 119.9]),
+        'dec': np.array([41.9, 42.2, 42.2]),
+        'id': np.array([1, 2, 3]),
+        'e1': np.array([0.2, 0.4, 0.4]),
+        'e2': np.array([0.3, 0.5, 0.5]),
+        'z': np.ones(3),
+        })
     angsep_units, bin_units = 'radians', 'radians'
     # Set up radial values
     bins_radians = np.array([0.002, 0.003, 0.004])
     expected_radius = [0.0021745039090962414, 0.0037238407383072053]
-    #######################################
-    ### Use without cluster object ########
-    #######################################
-    angsep, tshear, xshear = da.compute_tangential_and_cross_components(ra_lens=ra_lens, dec_lens=dec_lens,
-                                              ra_source=ra_source, dec_source=dec_source,
-                                              shear1=shear1, shear2=shear2)
-    # Tests passing int as bins arg makes the correct bins
-    bins = 2
-    vec_bins = clmm.utils.make_bins(np.min(angsep), np.max(angsep), bins)
-    testing.assert_array_equal(da.make_radial_profile([tshear, xshear, z_sources], angsep, angsep_units, bin_units, bins=bins)[0],
-                               da.make_radial_profile([tshear, xshear, z_sources], angsep, angsep_units, bin_units, bins=vec_bins)[0])
-    # Test the outputs of compute_tangential_and_cross_components just to be safe
-    expected_angsep = np.array([0.0021745039090962414, 0.0037238407383072053, 0.0037238407383072053])
-    expected_cross_shear = np.array([0.2780316984090899, 0.6398792901134982, 0.6398792901134982])
-    expected_tan_shear = np.array([-0.22956126563459447, -0.02354769805831558, -0.02354769805831558])
-    testing.assert_allclose(angsep, expected_angsep, **TOLERANCE,
-                            err_msg="Angular Separation not correct when testing shear profiles")
-    testing.assert_allclose(tshear, expected_tan_shear, **TOLERANCE,
-                            err_msg="Tangential Shear not correct when testing shear profiles")
-    testing.assert_allclose(xshear, expected_cross_shear, **TOLERANCE,
-                            err_msg="Cross Shear not correct when testing shear profiles")
-    # Test default behavior, remember that include_empty_bins=False excludes all bins with N>=1
-    profile = da.make_radial_profile([tshear, xshear, z_sources], angsep, angsep_units, bin_units,
-                                     bins=bins_radians, include_empty_bins=False)
-    _test_profile_table_output(profile, bins_radians[1], expected_radius[1], bins_radians[2],
-                               expected_tan_shear[1], expected_cross_shear[1], [2])
-    # Test metadata
-    testing.assert_array_equal(profile.meta['bin_units'], bin_units)
-    testing.assert_array_equal(profile.meta['cosmo'], None)
-    # Test simple unit convesion
-    profile = da.make_radial_profile([tshear, xshear, z_sources], angsep*180./np.pi, 'degrees', bin_units,
-                                     bins=bins_radians, include_empty_bins=False)
-    _test_profile_table_output(profile, bins_radians[1], expected_radius[1], bins_radians[2],
-                               expected_tan_shear[1], expected_cross_shear[1], [2])
-    # including empty bins
-    profile = da.make_radial_profile([tshear, xshear, z_sources], angsep, angsep_units, bin_units,
-                                     bins=bins_radians, include_empty_bins=True)
-    _test_profile_table_output(profile, bins_radians[:-1], expected_radius, bins_radians[1:],
-                               expected_tan_shear[:-1], expected_cross_shear[:-1], [1,2])
-    # test with return_binnumber
-    profile, binnumber = da.make_radial_profile([tshear, xshear, z_sources], angsep, angsep_units, bin_units,
-                                     bins=bins_radians, include_empty_bins=True, return_binnumber=True)
-    _test_profile_table_output(profile, bins_radians[:-1], expected_radius, bins_radians[1:],
-                               expected_tan_shear[:-1], expected_cross_shear[:-1], [1,2])
-    testing.assert_array_equal(binnumber, [1, 2, 2])
-    ###################################
-    ### Test with cluster object ######
-    ###################################
+    expected_flat = {
+        'angsep': np.array([0.0021745039090962414, 0.0037238407383072053, 0.0037238407383072053]),
+        'cross_shear': np.array([0.2780316984090899, 0.6398792901134982, 0.6398792901134982]),
+        'tan_shear': np.array([-0.22956126563459447, -0.02354769805831558, -0.02354769805831558]),
+    }
+    expected_curve = {# <<TO BE ADDED IN THE FUTURE>>
+        'angsep': np.array([]),
+        'cross_shear': np.array([]),
+        'tan_shear': np.array([]),
+    }
+    # Geometries to test
+    geo_tests = [('flat', expected_flat), ('curve', expected_curve)]
+    geo_tests = geo_tests[:1] # <<DELETE THIS LINE WHEN CURVE VALUES ADDED>>
+    for geometry, expected in geo_tests:
+        #######################################
+        ### Use without cluster object ########
+        #######################################
+        angsep, tshear, xshear = da.compute_tangential_and_cross_components(ra_lens=ra_lens, dec_lens=dec_lens,
+                                                  ra_source=gals['ra'], dec_source=gals['dec'],
+                                                  shear1=gals['e1'], shear2=gals['e2'], geometry=geometry)
+        # Tests passing int as bins arg makes the correct bins
+        bins = 2
+        vec_bins = clmm.utils.make_bins(np.min(angsep), np.max(angsep), bins)
+        testing.assert_array_equal(da.make_radial_profile([tshear, xshear, gals['z']], angsep, angsep_units, bin_units, bins=bins)[0],
+                                   da.make_radial_profile([tshear, xshear, gals['z']], angsep, angsep_units, bin_units, bins=vec_bins)[0])
+        # Test the outputs of compute_tangential_and_cross_components just to be safe
+        testing.assert_allclose(angsep, expected['angsep'], **TOLERANCE,
+                                err_msg="Angular Separation not correct when testing shear profiles")
+        testing.assert_allclose(tshear, expected['tan_shear'], **TOLERANCE,
+                                err_msg="Tangential Shear not correct when testing shear profiles")
+        testing.assert_allclose(xshear, expected['cross_shear'], **TOLERANCE,
+                                err_msg="Cross Shear not correct when testing shear profiles")
+        # Test default behavior, remember that include_empty_bins=False excludes all bins with N>=1
+        profile = da.make_radial_profile([tshear, xshear, gals['z']], angsep, angsep_units, bin_units,
+                                         bins=bins_radians, include_empty_bins=False)
+        _test_profile_table_output(profile, bins_radians[1], expected_radius[1], bins_radians[2],
+                                   expected['tan_shear'][1], expected['cross_shear'][1], [2])
+        # Test metadata
+        testing.assert_array_equal(profile.meta['bin_units'], bin_units)
+        testing.assert_array_equal(profile.meta['cosmo'], None)
+        # Test simple unit convesion
+        profile = da.make_radial_profile([tshear, xshear, gals['z']], angsep*180./np.pi, 'degrees', bin_units,
+                                         bins=bins_radians, include_empty_bins=False)
+        _test_profile_table_output(profile, bins_radians[1], expected_radius[1], bins_radians[2],
+                                   expected['tan_shear'][1], expected['cross_shear'][1], [2])
+        # including empty bins
+        profile = da.make_radial_profile([tshear, xshear, gals['z']], angsep, angsep_units, bin_units,
+                                         bins=bins_radians, include_empty_bins=True)
+        _test_profile_table_output(profile, bins_radians[:-1], expected_radius, bins_radians[1:],
+                                   expected['tan_shear'][:-1], expected['cross_shear'][:-1], [1,2])
+        # test with return_binnumber
+        profile, binnumber = da.make_radial_profile([tshear, xshear, gals['z']], angsep, angsep_units, bin_units,
+                                         bins=bins_radians, include_empty_bins=True, return_binnumber=True)
+        _test_profile_table_output(profile, bins_radians[:-1], expected_radius, bins_radians[1:],
+                                   expected['tan_shear'][:-1], expected['cross_shear'][:-1], [1,2])
+        testing.assert_array_equal(binnumber, [1, 2, 2])
+        ###################################
+        ### Test with cluster object ######
+        ###################################
+        cluster = clmm.GalaxyCluster(unique_id='blah', ra=ra_lens, dec=dec_lens, z=z_lens,
+                                     galcat=gals['ra', 'dec', 'e1', 'e2', 'z', 'id'])
+        cluster.compute_tangential_and_cross_components(geometry=geometry)
+        cluster.make_radial_profile(bin_units, bins=bins_radians, include_empty_bins=False)
+        # Test default behavior, remember that include_empty_bins=False excludes all bins with N>=1
+        _test_profile_table_output(cluster.profile, bins_radians[1], expected_radius[1], bins_radians[2],
+                                   expected['tan_shear'][1], expected['cross_shear'][1], [2],
+                                   p0='gt', p1='gx')
+        # including empty bins
+        cluster.make_radial_profile(bin_units, bins=bins_radians, include_empty_bins=True, table_name='profile2')
+        _test_profile_table_output(cluster.profile2, bins_radians[:-1], expected_radius, bins_radians[1:],
+                                   expected['tan_shear'][:-1], expected['cross_shear'][:-1], [1,2],
+                                   p0='gt', p1='gx')
+        # Test with galaxy id's
+        cluster.make_radial_profile(bin_units, bins=bins_radians, include_empty_bins=True,
+                                    gal_ids_in_bins=True, table_name='profile3')
+        _test_profile_table_output(cluster.profile3, bins_radians[:-1], expected_radius, bins_radians[1:],
+                                   expected['tan_shear'][:-1], expected['cross_shear'][:-1], [1,2], [[1],[2,3]],
+                                   p0='gt', p1='gx')
+        # Test it runs with galaxy id's and int bins
+        cluster.make_radial_profile(bin_units, bins=5, include_empty_bins=True,
+                                    gal_ids_in_bins=True, table_name='profile3')
+        # And overwriting table
+        cluster.make_radial_profile(bin_units, bins=bins_radians, include_empty_bins=True,
+                                    gal_ids_in_bins=True, table_name='profile3')
+        _test_profile_table_output(cluster.profile3, bins_radians[:-1], expected_radius, bins_radians[1:],
+                                   expected['tan_shear'][:-1], expected['cross_shear'][:-1], [1,2], [[1],[2,3]],
+                                   p0='gt', p1='gx')
+        # Test it runs with galaxy id's and int bins and no empty bins
+        cluster.make_radial_profile(bin_units, bins=bins_radians, include_empty_bins=False,
+                                    gal_ids_in_bins=True, table_name='profile3')
+        _test_profile_table_output(cluster.profile3, bins_radians[1], expected_radius[1], bins_radians[2],
+                                   expected['tan_shear'][1], expected['cross_shear'][1], [2],
+                                   p0='gt', p1='gx')
+    ########################################
+    ### Basic tests of cluster object ######
+    ########################################
     # Test error of missing redshift
     cluster = clmm.GalaxyCluster(unique_id='blah', ra=ra_lens, dec=dec_lens, z=z_lens,
-                                     galcat=GCData([ra_source, dec_source,
-                                                   shear1, shear2],
-                                                  names=('ra', 'dec', 'e1', 'e2')))
+                                     galcat=gals['ra', 'dec', 'e1', 'e2'])
     cluster.compute_tangential_and_cross_components()
     testing.assert_raises(TypeError, cluster.make_radial_profile, bin_units)
     # Test error of missing shear
     cluster = clmm.GalaxyCluster(unique_id='blah', ra=ra_lens, dec=dec_lens, z=z_lens,
-                                 galcat=GCData([ra_source, dec_source,
-                                               shear1, shear2, z_sources, id_source],
-                                              names=('ra', 'dec', 'e1', 'e2', 'z', 'id')))
+                                     galcat=gals['ra', 'dec', 'e1', 'e2', 'z', 'id'])
     testing.assert_raises(TypeError, cluster.make_radial_profile, bin_units)
-    # Test default behavior, remember that include_empty_bins=False excludes all bins with N>=1
-    cluster.compute_tangential_and_cross_components()
-    cluster.make_radial_profile(bin_units, bins=bins_radians, include_empty_bins=False)
-    _test_profile_table_output(cluster.profile, bins_radians[1], expected_radius[1], bins_radians[2],
-                               expected_tan_shear[1], expected_cross_shear[1], [2],
-                               p0='gt', p1='gx')
-    # including empty bins
-    cluster.make_radial_profile(bin_units, bins=bins_radians, include_empty_bins=True, table_name='profile2')
-    _test_profile_table_output(cluster.profile2, bins_radians[:-1], expected_radius, bins_radians[1:],
-                               expected_tan_shear[:-1], expected_cross_shear[:-1], [1,2],
-                               p0='gt', p1='gx')
-    # Test with galaxy id's
-    cluster.make_radial_profile(bin_units, bins=bins_radians, include_empty_bins=True,
-                                gal_ids_in_bins=True, table_name='profile3')
-    _test_profile_table_output(cluster.profile3, bins_radians[:-1], expected_radius, bins_radians[1:],
-                               expected_tan_shear[:-1], expected_cross_shear[:-1], [1,2], [[1],[2,3]],
-                               p0='gt', p1='gx')
-    # Test it runs with galaxy id's and int bins
-    cluster.make_radial_profile(bin_units, bins=5, include_empty_bins=True,
-                                gal_ids_in_bins=True, table_name='profile3')
-    # And overwriting table
-    cluster.make_radial_profile(bin_units, bins=bins_radians, include_empty_bins=True,
-                                gal_ids_in_bins=True, table_name='profile3')
-    _test_profile_table_output(cluster.profile3, bins_radians[:-1], expected_radius, bins_radians[1:],
-                               expected_tan_shear[:-1], expected_cross_shear[:-1], [1,2], [[1],[2,3]],
-                               p0='gt', p1='gx')
-    # Test it runs with galaxy id's and int bins and no empty bins
-    cluster.make_radial_profile(bin_units, bins=bins_radians, include_empty_bins=False,
-                                gal_ids_in_bins=True, table_name='profile3')
-    _test_profile_table_output(cluster.profile3, bins_radians[1], expected_radius[1], bins_radians[2],
-                               expected_tan_shear[1], expected_cross_shear[1], [2],
-                               p0='gt', p1='gx')
     # Test error with overwrite=False
+    cluster.compute_tangential_and_cross_components()
+    cluster.make_radial_profile(bin_units, bins=bins_radians, table_name='profile3')
     testing.assert_raises(AttributeError, cluster.make_radial_profile, bin_units, bins=bins_radians,
-                            include_empty_bins=True, gal_ids_in_bins=True, table_name='profile3', overwrite=False)
+                          table_name='profile3', overwrite=False)
     # Check error of missing id's
     cluster_noid = clmm.GalaxyCluster(unique_id='blah', ra=ra_lens, dec=dec_lens, z=z_lens,
-                                 galcat=GCData([ra_source, dec_source,
-                                               shear1, shear2, z_sources],
-                                              names=('ra', 'dec', 'e1', 'e2', 'z')))
+                                 galcat=gals['ra', 'dec', 'e1', 'e2', 'z'])
     cluster_noid.compute_tangential_and_cross_components()
     testing.assert_raises(TypeError, cluster_noid.make_radial_profile, bin_units, gal_ids_in_bins=True)


### PR DESCRIPTION
Computations for (theta, phi) without flatsky approximations. The notebook (Flat_sky_limitations.ipynb) shows a difference at 0.0001% level on the mass fitted (10,000 times smaller than the mass error).