### PR TITLE
addresses #394 and #403

### DIFF
--- a/examples/demo_generate_mock_cluster.ipynb
+++ b/examples/demo_generate_mock_cluster.ipynb
@@ -173,6 +173,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "* Noisy data: shape noise plus measurement error, all galaxies at the same redshift"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "noisy_data_src_z_e_err = mock.generate_galaxy_catalog(\n",
+    "    cluster_m, cluster_z, concentration, cosmo, src_z,\n",
+    "    shapenoise=0.05, mean_e_err=0.05, ngals=ngals)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "**WARNING:** Experimental feature. Uncertainties are created by simply drawing random numbers near the value specified by `mean_e_err`. Use at your own risk. This will be improved in future releases.\n",
+    "    \n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "- Noisy data: photo-z errors (and pdfs!), all galaxies at the same redshift"
    ]
   },
@@ -528,7 +557,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/tests/test_mockdata.py
+++ b/tests/test_mockdata.py
@@ -16,7 +16,7 @@ cosmo = Cosmology(H0 = 70.0, Omega_dm0 = 0.27 - 0.045, Omega_b0 = 0.045, Omega_k
 def test_mock_data():
     """ Run generate_galaxy_catalog 1000 times and assert that retrieved mass is always consistent with input
     """
-    
+
     # Basic raise tests
     assert_raises(ValueError, mock.generate_galaxy_catalog, 1e15, 0.3, 4, cosmo, 0.8, ngals=None)
     assert_raises(ValueError, mock.generate_galaxy_catalog, 1e15, 0.3, 4, cosmo, 0.8, ngals=1, ngal_density=1)
@@ -44,7 +44,10 @@ def test_mock_data():
     # Simple test to check if option with pdz is working
     # A proper test should be implemented
     mock.generate_galaxy_catalog(1e15, 0.3, 4, cosmo, 0.8, ngals=100, photoz_sigma_unscaled=.1)
-    
+    # Simple test to check if option with mean_e_err is working
+    # A proper test should be implemented
+    mock.generate_galaxy_catalog(1e15, 0.3, 4, cosmo, 0.8, ngals=100, mean_e_err=0.01)
+
     def nfw_shear_profile(r, logm, z_src):
         m = 10.**logm
         gt_model = clmm.compute_reduced_tangential_shear(r,
@@ -54,33 +57,33 @@ def test_mock_data():
         return gt_model
 
     def mass_mock_cluster(mass=15.,guess=15.):
-        
+
         # Set up mock cluster
         ngals=5000
         data = mock.generate_galaxy_catalog(10**mass, 0.3, 4, cosmo, 0.8, ngals=ngals)
-        
+
         # Check whether the given ngals is the retrieved ngals
         assert_equal(len(data['ra']),ngals)
-        
+
         # Check that there are no galaxies with |e|>1
         assert_equal(np.count_nonzero((data['e1']>1) | (data['e1']<-1)),0)
         assert_equal(np.count_nonzero((data['e2']>1) | (data['e2']<-1)),0)
-        
+
         # Create shear profile
         cl = clmm.GalaxyCluster("test_cluster", 0.0, 0.0, 0.3, data)
         theta, g_t, g_x = cl.compute_tangential_and_cross_components(geometry="flat")
-        binned = cl.make_radial_profile("Mpc", bins=da.make_bins(0.5, 5.0, 100), 
+        binned = cl.make_radial_profile("Mpc", bins=da.make_bins(0.5, 5.0, 100),
                                   cosmo=cosmo, include_empty_bins=False)
 
-        popt,pcov = fitters['curve_fit'](lambda r, logm: nfw_shear_profile(r, logm, 0.8), 
-                            binned['radius'], 
-                            binned['gt'], 
-                            np.ones_like(binned['gt'])*1.e-5, 
+        popt,pcov = fitters['curve_fit'](lambda r, logm: nfw_shear_profile(r, logm, 0.8),
+                            binned['radius'],
+                            binned['gt'],
+                            np.ones_like(binned['gt'])*1.e-5,
                             bounds=[13.,17.],p0=guess)
 
         return popt[0]
-    
-    
+
+
     #input_masses = np.random.uniform(13.5, 16., 25)
     #logm_0 = np.random.uniform(13.5, 16., 25)
     input_masses = np.array([13.82,15.94,13.97,14.17,14.95,15.49,14.93,15.59])
@@ -88,32 +91,32 @@ def test_mock_data():
     meas_masses = [mass_mock_cluster(m,g) for m,g in zip(input_masses,guess_masses)]
     assert_allclose(meas_masses,input_masses, **TOLERANCE)
 
-    
+
 def test_z_distr():
     """
     Test the redshift distribution options: single plan, uniform, Chang13, DESC SRD
-    """    
-    
+    """
+
     np.random.seed(256429)
-    
+
     # Set up mock cluster
     ngals=50000; mass=15.
     zmin=0.4; zmax=3.0
     bins = np.arange(zmin,zmax+0.1,0.1)
-    
+
     data = mock.generate_galaxy_catalog(10**mass, 0.3, 4, cosmo, 0.8, ngals=ngals)
     # Check that all galaxies are at z=0.8
     assert_equal(np.count_nonzero(data['z']!=0.8),0)
-    
+
     data = mock.generate_galaxy_catalog(10**mass, 0.3, 4, cosmo, 'uniform', ngals=260000,
                                         zsrc_min=zmin, zsrc_max=zmax)
-    
+
     # Check that all galaxies are within the given limits
     assert_equal(np.count_nonzero((data['z']<zmin)|(data['z']>zmax)),0)
     # Check that the z distribution is uniform
     hist = np.histogram(data['z'],bins=bins)
     assert_allclose(hist[0],10000*np.ones(len(hist[0])),atol=200,rtol=0.02)
-    
+
     # Check the Chang et al. (2013) redshift distribution
     data = mock.generate_galaxy_catalog(10**mass, 0.3, 4, cosmo, 'chang13', ngals=ngals,
                                         zsrc_min=zmin, zsrc_max=zmax)
@@ -137,15 +140,15 @@ def test_z_distr():
     # Expected number of galaxies in bin i = Ntot*distrib(z_{bin center})*binsize/norm
     srd = np.array([mock._srd_z_distrib(z)*ngals*0.1/norm for z in bins[:-1]+0.05])
     assert_allclose(hist[0],srd,atol=100,rtol=0.1)
-    
-    
-    
-    
+
+
+
+
 def test_shapenoise():
     """
     Test that the shape noise distribution is Gaussian around the shear and does not produce unphysical ellipticities.
-    """    
-    
+    """
+
     np.random.seed(285713)
 
     # Verify that shape noise does not produce unrealistic ellipticities
@@ -153,8 +156,8 @@ def test_shapenoise():
     # Check that there are no galaxies with |e|>1
     assert_equal(np.count_nonzero((data['e1']>1) | (data['e1']<-1)),0)
     assert_equal(np.count_nonzero((data['e2']>1) | (data['e2']<-1)),0)
-    
-    
+
+
     # Verify that the shape noise is Gaussian around 0 (for the very small shear here)
     sigma=0.25
     data = mock.generate_galaxy_catalog(10**12., 0.3, 4, cosmo, 0.8, ngals=50000,shapenoise=sigma)


### PR DESCRIPTION
Adds the posibility of having ellipcitity uncertainties when generating mock data, and provides more useful error messages when calling `mock_data.generate_galaxy_catalog` with the wrong arguments.

However, I had some trouble compiling the updated docs, and I'd like opinions on whether we want to include this in the mass fitting demos.