### PR TITLE
Issue/439/use comp red shear from generic

### DIFF
--- a/clmm/theory/ccl.py
+++ b/clmm/theory/ccl.py
@@ -143,32 +143,5 @@ class CCLCLMModeling(CLMModeling):
         dens = self.hdpm.projected(*args)
         return (mean_dens-dens)*self.cor_factor/a_cl**2
 
-    def eval_tangential_shear(self, r_proj, z_cl, z_src):
-        """"eval tangential shear"""
-        sigma_excess = self.eval_excess_surface_density(r_proj, z_cl)
-        sigma_crit = self.eval_critical_surface_density(z_cl, z_src)
-
-        return sigma_excess/sigma_crit
-
-    def eval_convergence(self, r_proj, z_cl, z_src):
-        """"eval convergence"""
-        sigma = self.eval_surface_density(r_proj, z_cl)
-        sigma_crit = self.eval_critical_surface_density(z_cl, z_src)
-
-        return sigma/sigma_crit
-
-    def eval_reduced_tangential_shear(self, r_proj, z_cl, z_src):
-        """"eval reduced tangential shear"""
-        kappa = self.eval_convergence(r_proj, z_cl, z_src)
-        gamma_t = self.eval_tangential_shear(r_proj, z_cl, z_src)
-
-        return np.divide(gamma_t, (1-kappa))
-
-    def eval_magnification(self, r_proj, z_cl, z_src):
-        """"eval magnification"""
-        kappa = self.eval_convergence(r_proj, z_cl, z_src)
-        gamma_t = self.eval_tangential_shear(r_proj, z_cl, z_src)
-
-        return 1.0/((1.0-kappa)**2-np.abs(gamma_t)**2)
 
 Modeling = CCLCLMModeling

--- a/clmm/theory/cluster_toolkit.py
+++ b/clmm/theory/cluster_toolkit.py
@@ -157,31 +157,5 @@ class CTModeling(CLMModeling):
             r_proj, sigma_r_proj, sigma, self.mdelta*h,
             self.cdelta, Omega_m, delta=self.delta_mdef)*h*1.0e12  # pc**-2 to Mpc**-2
 
-    def eval_tangential_shear(self, r_proj, z_cl, z_src):
-        """"eval tangential shear"""
-        delta_sigma = self.eval_excess_surface_density(r_proj, z_cl)
-        sigma_c = self.eval_critical_surface_density(z_cl, z_src)
-        return delta_sigma/sigma_c
-
-    def eval_convergence(self, r_proj, z_cl, z_src):
-        """"eval convergence"""
-        sigma = self.eval_surface_density(r_proj, z_cl)
-        sigma_c = self.eval_critical_surface_density(z_cl, z_src)
-        return sigma/sigma_c
-
-    def eval_reduced_tangential_shear(self, r_proj, z_cl, z_src):
-        """"eval reduced tangential shear"""
-        kappa = self.eval_convergence(r_proj, z_cl, z_src)
-        gamma_t = self.eval_tangential_shear(r_proj, z_cl, z_src)
-        return np.divide(gamma_t, (1-kappa))
-
-    def eval_magnification(self, r_proj, z_cl, z_src):
-        """"eval magnification"""
-        # The magnification is computed taking into account just the tangential
-        # shear. This is valid for spherically averaged profiles, e.g., NFW and
-        # Einasto (by construction the cross shear is zero).
-        kappa = self.eval_convergence(r_proj, z_cl, z_src)
-        gamma_t = self.eval_tangential_shear(r_proj, z_cl, z_src)
-        return 1./((1-kappa)**2-abs(gamma_t)**2)
 
 Modeling = CTModeling

--- a/clmm/theory/generic.py
+++ b/clmm/theory/generic.py
@@ -22,8 +22,7 @@ def compute_reduced_shear_from_convergence(shear, convergence):
 
     Returns
     -------
-    reduced_shear : array_like
+    array_like
         Reduced shear
     """
-    reduced_shear = np.array(shear)/(1.-np.array(convergence))
-    return reduced_shear
+    return np.array(shear)/(1.-np.array(convergence))

--- a/clmm/theory/parent_class.py
+++ b/clmm/theory/parent_class.py
@@ -2,6 +2,7 @@
 CLMModeling abstract class
 """
 import numpy as np
+from .generic import compute_reduced_shear_from_convergence
 
 
 class CLMModeling:
@@ -273,7 +274,9 @@ class CLMModeling:
         array_like, float
             tangential shear
         """
-        raise NotImplementedError
+        delta_sigma = self.eval_excess_surface_density(r_proj, z_cl)
+        sigma_c = self.eval_critical_surface_density(z_cl, z_src)
+        return delta_sigma/sigma_c
 
     def eval_convergence(self, r_proj, z_cl, z_src):
         r"""Computes the mass convergence
@@ -304,7 +307,9 @@ class CLMModeling:
         -----
         Need to figure out if we want to raise exceptions rather than errors here?
         """
-        raise NotImplementedError
+        sigma = self.eval_surface_density(r_proj, z_cl)
+        sigma_c = self.eval_critical_surface_density(z_cl, z_src)
+        return sigma/sigma_c
 
     def eval_reduced_tangential_shear(self, r_proj, z_cl, z_src):
         r"""Computes the reduced tangential shear :math:`g_t = \frac{\gamma_t}{1-\kappa}`.
@@ -327,7 +332,9 @@ class CLMModeling:
         -----
         Need to figure out if we want to raise exceptions rather than errors here?
         """
-        raise NotImplementedError
+        kappa = self.eval_convergence(r_proj, z_cl, z_src)
+        gamma_t = self.eval_tangential_shear(r_proj, z_cl, z_src)
+        return compute_reduced_shear_from_convergence(gamma_t, kappa)
 
     def eval_magnification(self, r_proj, z_cl, z_src):
         r"""Computes the magnification
@@ -351,6 +358,10 @@ class CLMModeling:
 
         Notes
         -----
-        Need to figure out if we want to raise exceptions rather than errors here?
+        The magnification is computed taking into account just the tangential
+        shear. This is valid for spherically averaged profiles, e.g., NFW and
+        Einasto (by construction the cross shear is zero).
         """
-        raise NotImplementedError
+        kappa = self.eval_convergence(r_proj, z_cl, z_src)
+        gamma_t = self.eval_tangential_shear(r_proj, z_cl, z_src)
+        return 1./((1-kappa)**2-abs(gamma_t)**2)


### PR DESCRIPTION
Using `theory.generic.compute_reduced_shear_from_convergence` function for computations in classes (excluding numcosmo). I also noted there were other functions in `cluster_toolkit` and `ccl` backends that only used internal generic products, so I moved them to the parent class.