### PR TITLE
Issue/507/ccl_eval_da

### DIFF
--- a/clmm/__init__.py
+++ b/clmm/__init__.py
@@ -12,4 +12,4 @@ from .theory import (
 )
 from . import support
 
-__version__ = '1.1.9'
+__version__ = '1.1.10'

--- a/clmm/cosmology/ccl.py
+++ b/clmm/cosmology/ccl.py
@@ -86,7 +86,7 @@ class CCLCosmology(CLMMCosmology):
         a2 = np.atleast_1d(self.get_a_from_z(z2))
         if len(a1)==1 and len(a2)!=1:
             a1 = np.repeat(a1, len(a2))
-        if len(a2)==1 and len(a1)!=1:
+        elif len(a2)==1 and len(a1)!=1:
             a2 = np.repeat(a2, len(a1))
 
         sign = np.sign(a1-a2)

--- a/clmm/cosmology/ccl.py
+++ b/clmm/cosmology/ccl.py
@@ -81,7 +81,7 @@ class CCLCosmology(CLMMCosmology):
         a = self.get_a_from_z(z)
         return ccl.rho_x(self.be_cosmo, a, 'matter', is_comoving = False)
 
-    def _eval_da_z1z2(self, z1, z2):
+    def _eval_da_z1z2_core(self, z1, z2):
         a1 = np.atleast_1d(self.get_a_from_z(z1))
         a2 = np.atleast_1d(self.get_a_from_z(z2))
         if len(a1)==1 and len(a2)!=1:

--- a/clmm/cosmology/ccl.py
+++ b/clmm/cosmology/ccl.py
@@ -94,7 +94,7 @@ class CCLCosmology(CLMMCosmology):
 
         return res
 
-    def _eval_sigma_crit(self, z_len, z_src):
+    def _eval_sigma_crit_core(self, z_len, z_src):
         cte = ccl.physical_constants.CLIGHT**2 / \
             (4.0*np.pi*ccl.physical_constants.GNEWT *
              ccl.physical_constants.SOLAR_MASS)*ccl.physical_constants.MPC_TO_METER

--- a/clmm/cosmology/ccl.py
+++ b/clmm/cosmology/ccl.py
@@ -103,17 +103,7 @@ class CCLCosmology(CLMMCosmology):
         Dl = self.eval_da_z1z2(0, z_len)
         Dls = self.eval_da_z1z2(z_len, z_src)
 
-        res = np.atleast_1d((cte*Ds/(Dl*Dls))*self.cor_factor)
-        if np.any(np.array(z_src) <= z_len):
-            warnings.warn(
-                'Some source redshifts are lower than the cluster redshift.'
-                'Returning Sigma_crit = np.inf for those galaxies.')
-            res[res<0] = np.Inf
-
-        if np.isscalar(z_len) and np.isscalar(z_src):
-            return res.item()
-        else:
-            return res
+        return (cte*Ds/(Dl*Dls))*self.cor_factor
 
     def _eval_linear_matter_powerspectrum(self, k_vals, redshift):
         return ccl.linear_matter_power(

--- a/clmm/cosmology/ccl.py
+++ b/clmm/cosmology/ccl.py
@@ -99,9 +99,9 @@ class CCLCosmology(CLMMCosmology):
             (4.0*np.pi*ccl.physical_constants.GNEWT *
              ccl.physical_constants.SOLAR_MASS)*ccl.physical_constants.MPC_TO_METER
 
-        Ds = self.eval_da_z1z2(0, z_src)
-        Dl = self.eval_da_z1z2(0, z_len)
-        Dls = self.eval_da_z1z2(z_len, z_src)
+        Ds = self._eval_da_z1z2_core(0, z_src)
+        Dl = self._eval_da_z1z2_core(0, z_len)
+        Dls = self._eval_da_z1z2_core(z_len, z_src)
 
         return (cte*Ds/(Dl*Dls))*self.cor_factor
 

--- a/clmm/cosmology/ccl.py
+++ b/clmm/cosmology/ccl.py
@@ -89,16 +89,10 @@ class CCLCosmology(CLMMCosmology):
         elif len(a2)==1 and len(a1)!=1:
             a2 = np.repeat(a2, len(a1))
 
-        sign = np.sign(a1-a2)
-        swap = sign<0
-        a1[swap], a2[swap] = a2[swap], a1[swap]
-        da = ccl.angular_diameter_distance(self.be_cosmo, a1, a2)*sign
-        da[swap] *= a1[swap]/a2[swap]
+        da = ccl.angular_diameter_distance(self.be_cosmo, a1, a2)
+        res = da if np.iterable(z1) or np.iterable(z2) else da.item()
 
-        if np.isscalar(z1) and np.isscalar(z2):
-            return da.item()
-        else:
-            return da
+        return res
 
     def _eval_sigma_crit(self, z_len, z_src):
         cte = ccl.physical_constants.CLIGHT**2 / \

--- a/clmm/cosmology/ccl.py
+++ b/clmm/cosmology/ccl.py
@@ -85,9 +85,9 @@ class CCLCosmology(CLMMCosmology):
         a1 = np.atleast_1d(self.get_a_from_z(z1))
         a2 = np.atleast_1d(self.get_a_from_z(z2))
         if len(a1)==1 and len(a2)!=1:
-            a1 = np.repeat(a1, len(a2))
+            a1 = np.full_like(a2, a1)
         elif len(a2)==1 and len(a1)!=1:
-            a2 = np.repeat(a2, len(a1))
+            a2 = np.full_like(a1, a2)
 
         da = ccl.angular_diameter_distance(self.be_cosmo, a1, a2)
         res = da if np.iterable(z1) or np.iterable(z2) else da.item()

--- a/clmm/cosmology/cluster_toolkit.py
+++ b/clmm/cosmology/cluster_toolkit.py
@@ -79,7 +79,7 @@ class AstroPyCosmology(CLMMCosmology):
     def _get_E2Omega_m(self, z):
         return self.be_cosmo.Om(z)*(self.be_cosmo.H(z)/self.be_cosmo.H0)**2
 
-    def _eval_da_z1z2(self, z1, z2):
+    def _eval_da_z1z2_core(self, z1, z2):
         return self.be_cosmo.angular_diameter_distance_z1z2(z1, z2).to_value(units.Mpc)
 
     def _eval_sigma_crit(self, z_len, z_src):

--- a/clmm/cosmology/cluster_toolkit.py
+++ b/clmm/cosmology/cluster_toolkit.py
@@ -88,8 +88,8 @@ class AstroPyCosmology(CLMMCosmology):
         gnewt_pc3_msun_s2 = const.GNEWT.value * \
             const.SOLAR_MASS.value/const.PC_TO_METER.value**3
 
-        d_l = self.eval_da_z1z2(0, z_len)
-        d_s = self.eval_da_z1z2(0, z_src)
-        d_ls = self.eval_da_z1z2(z_len, z_src)
+        d_l = self._eval_da_z1z2_core(0, z_len)
+        d_s = self._eval_da_z1z2_core(0, z_src)
+        d_ls = self._eval_da_z1z2_core(z_len, z_src)
 
         return clight_pc_s**2/(4.0*np.pi*gnewt_pc3_msun_s2)*d_s/(d_l*d_ls)*1.0e6

--- a/clmm/cosmology/cluster_toolkit.py
+++ b/clmm/cosmology/cluster_toolkit.py
@@ -83,10 +83,6 @@ class AstroPyCosmology(CLMMCosmology):
         return self.be_cosmo.angular_diameter_distance_z1z2(z1, z2).to_value(units.Mpc)
 
     def _eval_sigma_crit_core(self, z_len, z_src):
-        if np.any(np.array(z_src) <= z_len):
-            warnings.warn(
-                'Some source redshifts are lower than the cluster redshift. '
-                'Returning Sigma_crit = np.inf for those galaxies.')
         # Constants
         clight_pc_s = const.CLIGHT_KMS.value*1000./const.PC_TO_METER.value
         gnewt_pc3_msun_s2 = const.GNEWT.value * \
@@ -96,5 +92,4 @@ class AstroPyCosmology(CLMMCosmology):
         d_s = self.eval_da_z1z2(0, z_src)
         d_ls = self.eval_da_z1z2(z_len, z_src)
 
-        beta_s = np.maximum(0., d_ls/d_s)
-        return clight_pc_s**2/(4.0*np.pi*gnewt_pc3_msun_s2)*1/d_l*np.divide(1., beta_s)*1.0e6
+        return clight_pc_s**2/(4.0*np.pi*gnewt_pc3_msun_s2)*d_s/(d_l*d_ls)*1.0e6

--- a/clmm/cosmology/cluster_toolkit.py
+++ b/clmm/cosmology/cluster_toolkit.py
@@ -82,7 +82,7 @@ class AstroPyCosmology(CLMMCosmology):
     def _eval_da_z1z2_core(self, z1, z2):
         return self.be_cosmo.angular_diameter_distance_z1z2(z1, z2).to_value(units.Mpc)
 
-    def _eval_sigma_crit(self, z_len, z_src):
+    def _eval_sigma_crit_core(self, z_len, z_src):
         if np.any(np.array(z_src) <= z_len):
             warnings.warn(
                 'Some source redshifts are lower than the cluster redshift. '

--- a/clmm/cosmology/numcosmo.py
+++ b/clmm/cosmology/numcosmo.py
@@ -126,7 +126,7 @@ class NumCosmoCosmology(CLMMCosmology):
         return np.vectorize(self.dist.angular_diameter_z1_z2)(
             self.be_cosmo, z1, z2)*self.be_cosmo.RH_Mpc()
 
-    def _eval_sigma_crit(self, z_len, z_src):
+    def _eval_sigma_crit_core(self, z_len, z_src):
 
         self.smd.prepare_if_needed(self.be_cosmo)
 

--- a/clmm/cosmology/numcosmo.py
+++ b/clmm/cosmology/numcosmo.py
@@ -143,7 +143,7 @@ class NumCosmoCosmology(CLMMCosmology):
         # Instead, computing the PS from the CLASS backend of Numcosmo
         # ps  = Nc.PowspecMLCBE.new ()
         # ps.peek_cbe().props.use_ppf = True
-     
+
         if self.be_cosmo.reion is None:
             reion = Nc.HIReionCamb.new ()
             self.be_cosmo.add_submodel (reion)
@@ -158,7 +158,7 @@ class NumCosmoCosmology(CLMMCosmology):
             self.be_cosmo.prim.props.ln10e10ASA = np.log ((0.8 / self.be_cosmo.sigma8(psf))**2 * old_amplitude)
 
         ps.prepare (self.be_cosmo)
-        
+
         res = []
         for k in k_vals:
             res.append(ps.eval (self.be_cosmo, redshift, k))

--- a/clmm/cosmology/numcosmo.py
+++ b/clmm/cosmology/numcosmo.py
@@ -121,7 +121,7 @@ class NumCosmoCosmology(CLMMCosmology):
             self._get_param('h') * self._get_param('h')
         return rho_m
 
-    def _eval_da_z1z2(self, z1, z2):
+    def _eval_da_z1z2_core(self, z1, z2):
 
         return np.vectorize(self.dist.angular_diameter_z1_z2)(
             self.be_cosmo, z1, z2)*self.be_cosmo.RH_Mpc()

--- a/clmm/cosmology/parent_class.py
+++ b/clmm/cosmology/parent_class.py
@@ -288,7 +288,7 @@ class CLMMCosmology:
         Returns
         -------
         a : float, numpy.ndarray
-             Scale factor
+            Scale factor
         """
         if self.validate_input:
             validate_argument(locals(), 'z', 'float_array', argmin=0, eqmin=True)

--- a/clmm/cosmology/parent_class.py
+++ b/clmm/cosmology/parent_class.py
@@ -2,7 +2,7 @@
 """
 # CLMM Cosmology object abstract superclass
 import numpy as np
-from ..utils import validate_argument
+from ..utils import validate_argument, compute_for_good_redshifts
 from ..constants import Constants as const
 
 
@@ -205,6 +205,11 @@ class CLMMCosmology:
         return self._eval_da_z1z2(z1=z1, z2=z2)
 
     def _eval_da_z1z2(self, z1, z2):
+        return compute_for_good_redshifts(
+            self._eval_da_z1z2_core, z1, z2, np.nan,
+            error_message='Some values of z2 are lower z1. Returning da = np.nan for those.')
+
+    def _eval_da_z1z2_core(self, z1, z2):
         raise NotImplementedError
 
     def eval_da(self, z):
@@ -367,6 +372,12 @@ class CLMMCosmology:
         return self._eval_sigma_crit(z_len=z_len, z_src=z_src)
 
     def _eval_sigma_crit(self, z_len, z_src):
+        return compute_for_good_redshifts(
+            self._eval_sigma_crit_core, z1, z2, np.inf,
+            error_message='Some source redshifts are lower than the cluster redshift. '
+                          'Returning Sigma_crit = np.inf for those galaxies.')
+
+    def _eval_sigma_crit_core(self, z_len, z_src):
         raise NotImplementedError
 
     def eval_linear_matter_powerspectrum(self, k_vals, redshift):

--- a/clmm/cosmology/parent_class.py
+++ b/clmm/cosmology/parent_class.py
@@ -207,7 +207,7 @@ class CLMMCosmology:
     def _eval_da_z1z2(self, z1, z2):
         return compute_for_good_redshifts(
             self._eval_da_z1z2_core, z1, z2, np.nan,
-            error_message='Some values of z2 are lower z1. Returning da = np.nan for those.')
+            error_message='Some values of z2 are lower than z1. Returning da = np.nan for those.')
 
     def _eval_da_z1z2_core(self, z1, z2):
         raise NotImplementedError

--- a/clmm/cosmology/parent_class.py
+++ b/clmm/cosmology/parent_class.py
@@ -322,7 +322,7 @@ class CLMMCosmology:
         ----------
         dist1 : float, array_like
             Input distances in radians
-        redshift : float, array_like
+        redshift : float
             Redshift used to convert between angular and physical units
         cosmo : astropy.cosmology
             Astropy cosmology object to compute angular diameter distance to
@@ -337,7 +337,7 @@ class CLMMCosmology:
         """
         if self.validate_input:
             validate_argument(locals(), 'dist1', 'float_array', argmin=0, eqmin=True)
-            validate_argument(locals(), 'redshift', 'float_array', argmin=0, eqmin=True)
+            validate_argument(locals(), 'redshift', float, argmin=0, eqmin=True)
         return dist1*self.eval_da(redshift)
 
     def mpc2rad(self, dist1, redshift):
@@ -348,7 +348,7 @@ class CLMMCosmology:
         ----------
         dist1 : float, array_like
             Input distances in Mpc
-        redshift : float, array_like
+        redshift : float
             Redshift used to convert between angular and physical units
         cosmo : astropy.cosmology
             Astropy cosmology object to compute angular diameter distance to
@@ -363,7 +363,7 @@ class CLMMCosmology:
         """
         if self.validate_input:
             validate_argument(locals(), 'dist1', 'float_array', argmin=0, eqmin=True)
-            validate_argument(locals(), 'redshift', 'float_array', argmin=0, eqmin=True)
+            validate_argument(locals(), 'redshift', float, argmin=0, eqmin=True)
         return dist1/self.eval_da(redshift)
 
     def eval_sigma_crit(self, z_len, z_src):
@@ -412,6 +412,7 @@ class CLMMCosmology:
         """
         if self.validate_input:
             validate_argument(locals(), 'k_vals', 'float_array', argmin=0)
+            validate_argument(locals(), 'redshift', float, argmin=0, eqmin=True)
         return self._eval_linear_matter_powerspectrum(k_vals, redshift)
 
     def _eval_linear_matter_powerspectrum(self, k_vals, redshift):

--- a/clmm/cosmology/parent_class.py
+++ b/clmm/cosmology/parent_class.py
@@ -327,8 +327,6 @@ class CLMMCosmology:
         cosmo : CLMMCosmology
             CLMMCosmology object to compute angular diameter distance to
             convert between physical and angular units
-        do_inverse : bool
-            If true, converts Mpc to radians
 
         Returns
         -------
@@ -353,8 +351,6 @@ class CLMMCosmology:
         cosmo : CLMMCosmology
             CLMMCosmology object to compute angular diameter distance to
             convert between physical and angular units
-        do_inverse : bool
-            If true, converts Mpc to radians
 
         Returns
         -------

--- a/clmm/cosmology/parent_class.py
+++ b/clmm/cosmology/parent_class.py
@@ -324,8 +324,8 @@ class CLMMCosmology:
             Input distances in radians
         redshift : float
             Redshift used to convert between angular and physical units
-        cosmo : astropy.cosmology
-            Astropy cosmology object to compute angular diameter distance to
+        cosmo : CLMMCosmology
+            CLMMCosmology object to compute angular diameter distance to
             convert between physical and angular units
         do_inverse : bool
             If true, converts Mpc to radians
@@ -350,8 +350,8 @@ class CLMMCosmology:
             Input distances in Mpc
         redshift : float
             Redshift used to convert between angular and physical units
-        cosmo : astropy.cosmology
-            Astropy cosmology object to compute angular diameter distance to
+        cosmo : CLMMCosmology
+            CLMMCosmology object to compute angular diameter distance to
             convert between physical and angular units
         do_inverse : bool
             If true, converts Mpc to radians

--- a/clmm/cosmology/parent_class.py
+++ b/clmm/cosmology/parent_class.py
@@ -203,7 +203,7 @@ class CLMMCosmology:
 
         Notes
         -----
-        Describe the vectorization.
+        np.nan is returned for z1>z2.
         """
         if self.validate_input:
             validate_argument(locals(), 'z1', 'float_array', argmin=0, eqmin=True)
@@ -370,6 +370,10 @@ class CLMMCosmology:
         -------
         float, numpy.ndarray
             Cosmology-dependent critical surface density in units of :math:`M_\odot\ Mpc^{-2}`
+
+        Notes
+        -----
+        np.inf is returned for z_src<z_len.
         """
         if self.validate_input:
             validate_argument(locals(), 'z_len', float, argmin=0, eqmin=True)

--- a/clmm/cosmology/parent_class.py
+++ b/clmm/cosmology/parent_class.py
@@ -114,12 +114,14 @@ class CLMMCosmology:
 
         Parameters
         ----------
-        z : float
-            Redshift.
+        z : float, array_like
+            Redshift
+
         Returns
         -------
-        Omega_m : float
-            dimensionless matter density, :math:`\Omega_m(z)`.
+        Omega_m : float, numpy.ndarray
+            Dimensionless matter density, :math:`\Omega_m(z)`
+
         Notes
         -----
         Need to decide if non-relativist neutrinos will contribute here.
@@ -132,7 +134,7 @@ class CLMMCosmology:
         raise NotImplementedError
 
     def get_E2Omega_m(self, z):
-        r"""Gets the value of the dimensionless matter density times hubble parameter
+        r"""Gets the value of the dimensionless matter density times the Hubble parameter squared
         (normalized at 0)
 
         .. math::
@@ -140,12 +142,14 @@ class CLMMCosmology:
 
         Parameters
         ----------
-        z : float
-            Redshift.
+        z : float, array_like
+            Redshift
+
         Returns
         -------
-        Omega_m : float
-            dimensionless matter density, :math:`\Omega_m(z)\;H(z)^{2}/H_{0}^{2}`.
+        Omega_m : float, numpy.ndarray
+            Dimensionless matter density, :math:`\Omega_m(z)\times H(z)^{2}/H_{0}^{2}`
+
         Notes
         -----
         Need to decide if non-relativist neutrinos will contribute here.
@@ -162,13 +166,13 @@ class CLMMCosmology:
 
         Parameters
         ----------
-        z : float
-            Redshift.
+        z : float, array_like
+            Redshift
 
         Returns
         -------
-        float
-            Matter density :math:`M_\odot\ Mpc^{-3}`.
+        float, numpy.ndarray
+            Matter density :math:`M_\odot\ Mpc^{-3}`
         """
         if self.validate_input:
             validate_argument(locals(), 'z', 'float_array', argmin=0, eqmin=True)
@@ -180,21 +184,23 @@ class CLMMCosmology:
         return rhocrit_cd2018*(z+1)**3*self['Omega_m0']*self['h']**2
 
     def eval_da_z1z2(self, z1, z2):
-        r"""Computes the angular diameter distance between z1 and z2.
+        r"""Computes the angular diameter distance between z1 and z2
 
         .. math::
-            d_a(z1, z2) = \frac{c}{H_0}\frac{1}{1+z2}\int_{z1}^{z2}\frac{dz'}{E(z')}
+            d_a(z1, z2) = \frac{c}{H_0}\frac{1}{1+z2}\int_{z1}^{z2}\frac{dz'}{E(z')}.
 
         Parameters
         ----------
-        z1 : float
-            Redshift.
-        z2 : float
-            Redshift.
+        z1 : float, array_like
+            Redshift
+        z2 : float, array_like
+            Redshift
+
         Returns
         -------
-        float
+        float, numpy.ndarray
             Angular diameter distance in units :math:`M\!pc`
+
         Notes
         -----
         Describe the vectorization.
@@ -213,19 +219,21 @@ class CLMMCosmology:
         raise NotImplementedError
 
     def eval_da(self, z):
-        r"""Computes the angular diameter distance between 0.0 and z.
+        r"""Computes the angular diameter distance between 0.0 and z
 
         .. math::
-            d_a(z) = \frac{c}{H_0}\frac{1}{1+z}\int_{0}^{z}\frac{dz'}{E(z')}
+            d_a(z) = \frac{c}{H_0}\frac{1}{1+z}\int_{0}^{z}\frac{dz'}{E(z')}.
 
         Parameters
         ----------
-        z : float
-            Redshift.
+        z : float, array_like
+            Redshift
+
         Returns
         -------
-        float
+        float, numpy.ndarray
             Angular diameter distance in units :math:`M\!pc`
+
         Notes
         -----
         Describe the vectorization.
@@ -250,13 +258,14 @@ class CLMMCosmology:
 
         Parameters
         ----------
-        a1 : float
-            Scale factor.
-        a2 : float, optional
-            Scale factor.
+        a1 : float, array_like
+            Scale factor
+        a2 : float, array_like, optional
+            Scale factor
+
         Returns
         -------
-        float
+        float, numpy.ndarray
             Angular diameter distance in units :math:`M\!pc`
         """
         if self.validate_input:
@@ -269,15 +278,17 @@ class CLMMCosmology:
         return self.eval_da_z1z2(z1, z2)
 
     def get_a_from_z(self, z):
-        """ Convert redshift to scale factor
+        """Convert redshift to scale factor
+
         Parameters
         ----------
-        z : array_like
+        z : float, array_like
             Redshift
+
         Returns
         -------
-        scale_factor : array_like
-            Scale factor
+        a : float, numpy.ndarray
+             Scale factor
         """
         if self.validate_input:
             validate_argument(locals(), 'z', 'float_array', argmin=0, eqmin=True)
@@ -285,14 +296,16 @@ class CLMMCosmology:
         return 1.0/(1.0+z)
 
     def get_z_from_a(self, a):
-        """ Convert scale factor to redshift
+        """Convert scale factor to redshift
+
         Parameters
         ----------
-        a : array_like
+        a : float, array_like
             Scale factor
+
         Returns
         -------
-        z : array_like
+        z : float, numpy.ndarray
             Redshift
         """
         if self.validate_input:
@@ -302,23 +315,24 @@ class CLMMCosmology:
         return (1.0/a)-1.0
 
     def rad2mpc(self, dist1, redshift):
-        r""" Convert between radians and Mpc using the small angle approximation
+        r"""Convert between radians and Mpc using the small angle approximation
         and :math:`d = D_A \theta`.
 
         Parameters
         ----------
-        dist1 : array_like
+        dist1 : float, array_like
             Input distances in radians
-        redshift : float
+        redshift : float, array_like
             Redshift used to convert between angular and physical units
         cosmo : astropy.cosmology
             Astropy cosmology object to compute angular diameter distance to
             convert between physical and angular units
         do_inverse : bool
             If true, converts Mpc to radians
+
         Returns
         -------
-        dist2 : array_like
+        dist2 : float, numpy.ndarray
             Distances in Mpc
         """
         if self.validate_input:
@@ -327,23 +341,24 @@ class CLMMCosmology:
         return dist1*self.eval_da(redshift)
 
     def mpc2rad(self, dist1, redshift):
-        r""" Convert between radians and Mpc using the small angle approximation
+        r"""Convert between radians and Mpc using the small angle approximation
         and :math:`d = D_A \theta`.
 
         Parameters
         ----------
-        dist1 : array_like
+        dist1 : float, array_like
             Input distances in Mpc
-        redshift : float
+        redshift : float, array_like
             Redshift used to convert between angular and physical units
         cosmo : astropy.cosmology
             Astropy cosmology object to compute angular diameter distance to
             convert between physical and angular units
         do_inverse : bool
             If true, converts Mpc to radians
+
         Returns
         -------
-        dist2 : array_like
+        dist2 : float, numpy.ndarray
             Distances in radians
         """
         if self.validate_input:
@@ -358,12 +373,12 @@ class CLMMCosmology:
         ----------
         z_len : float
             Lens redshift
-        z_src : array_like, float
+        z_src : float, array_like
             Background source galaxy redshift(s)
 
         Returns
         -------
-        float
+        float, numpy.ndarray
             Cosmology-dependent critical surface density in units of :math:`M_\odot\ Mpc^{-2}`
         """
         if self.validate_input:
@@ -385,15 +400,15 @@ class CLMMCosmology:
 
         Parameters
         ----------
-        k_vals : array_like, float
+        k_vals : float, array_like
             Wavenumber k [math:`Mpc^{-1}`] values to compute the power spectrum.
         redshift : float
             Redshift to get the power spectrum.
 
         Returns
         -------
-        array_like, float
-            Linear matter spectrum in units of math:`Mpc^{3}`.
+        float, numpy.ndarray
+            Linear matter spectrum in units of math:`Mpc^{3}`
         """
         if self.validate_input:
             validate_argument(locals(), 'k_vals', 'float_array', argmin=0)

--- a/clmm/cosmology/parent_class.py
+++ b/clmm/cosmology/parent_class.py
@@ -324,9 +324,6 @@ class CLMMCosmology:
             Input distances in radians
         redshift : float
             Redshift used to convert between angular and physical units
-        cosmo : CLMMCosmology
-            CLMMCosmology object to compute angular diameter distance to
-            convert between physical and angular units
 
         Returns
         -------
@@ -348,9 +345,6 @@ class CLMMCosmology:
             Input distances in Mpc
         redshift : float
             Redshift used to convert between angular and physical units
-        cosmo : CLMMCosmology
-            CLMMCosmology object to compute angular diameter distance to
-            convert between physical and angular units
 
         Returns
         -------

--- a/clmm/cosmology/parent_class.py
+++ b/clmm/cosmology/parent_class.py
@@ -373,7 +373,7 @@ class CLMMCosmology:
 
     def _eval_sigma_crit(self, z_len, z_src):
         return compute_for_good_redshifts(
-            self._eval_sigma_crit_core, z1, z2, np.inf,
+            self._eval_sigma_crit_core, z_len, z_src, np.inf,
             error_message='Some source redshifts are lower than the cluster redshift. '
                           'Returning Sigma_crit = np.inf for those galaxies.')
 

--- a/clmm/utils.py
+++ b/clmm/utils.py
@@ -1,4 +1,5 @@
 """General utility functions that are used in multiple modules"""
+import warnings
 import numpy as np
 from scipy.stats import binned_statistic
 from scipy.special import gamma, gammainc
@@ -569,6 +570,36 @@ def validate_argument(loc, argname, valid_type, none_ok=False, argmin=None, argm
                 err = f'{argname} must be lesser than {argmax},' \
                       f' received {"vec_max:"*(var_array.size-1)}{var}'
                 raise ValueError(err)
+
+def compute_for_good_redshifts(function, z1, z2, bad_value, error_message):
+    """Computes function only for z1>z2, the rest is filled with bad_value
+
+    Parameters
+    ----------
+    function: function
+        Function to be executed
+    z1: float, array
+        Redshift lower
+    z2: float, array
+        Redshift higher
+    bad_value: any
+        Value to be added when z1>=z2
+    error_message: str
+        Message to be displayed
+    """
+    z_good = (np.array(z1)<np.array(z2))
+    if not z_good.all():
+        warnings.warn(error_message)
+        if np.iterable(z1) or np.iterable(z2):
+            res = np.full(z_good.size, bad_value)
+            res[z_good] = function(
+                z1[z_good] if np.iterable(z1) else z1,
+                z2[z_good] if np.iterable(z2) else z2)
+        else:
+            res = bad_value
+    else:
+        res = function(z1, z2)
+    return res
 
 def compute_beta(z_s, z_cl, cosmo):
     r"""Geometric lensing efficicency  

--- a/clmm/utils.py
+++ b/clmm/utils.py
@@ -587,14 +587,17 @@ def compute_for_good_redshifts(function, z1, z2, bad_value, error_message):
     error_message: str
         Message to be displayed
     """
-    z_good = (np.array(z1)<np.array(z2))
-    if not z_good.all():
+    z_good = np.less(z1, z2)
+    if not np.all(z_good):
         warnings.warn(error_message)
-        if np.iterable(z1) or np.iterable(z2):
+        if np.iterable(z_good):
             res = np.full(z_good.size, bad_value)
-            res[z_good] = function(
-                z1[z_good] if np.iterable(z1) else z1,
-                z2[z_good] if np.iterable(z2) else z2)
+            if np.any(z_good):
+                res[z_good] = function(
+                    np.array(z1)[z_good] if np.iterable(z1) else z1,
+                    np.array(z2)[z_good] if np.iterable(z2) else z2)
+            else:
+                pass
         else:
             res = bad_value
     else:

--- a/clmm/utils.py
+++ b/clmm/utils.py
@@ -593,8 +593,6 @@ def compute_for_good_redshifts(function, z1, z2, bad_value, error_message):
                 res[z_good] = function(
                     np.array(z1)[z_good] if np.iterable(z1) else z1,
                     np.array(z2)[z_good] if np.iterable(z2) else z2)
-            else:
-                pass
         else:
             res = bad_value
     else:

--- a/clmm/utils.py
+++ b/clmm/utils.py
@@ -575,9 +575,9 @@ def compute_for_good_redshifts(function, z1, z2, bad_value, error_message):
     ----------
     function: function
         Function to be executed
-    z1: float, array
+    z1: float, array_like
         Redshift lower
-    z2: float, array
+    z2: float, array_like
         Redshift higher
     bad_value: any
         Value to be added when z1>=z2

--- a/clmm/utils.py
+++ b/clmm/utils.py
@@ -37,7 +37,6 @@ def compute_nfw_boost(rvals, rs=1000, b0=0.1) :
         return np.nan_to_num(finternal, copy=False, nan=1.0).real
 
     return 1. + b0 * (1 - _calc_finternal(x)) / (x**2 - 1)
-        
 
 
 def compute_powerlaw_boost(rvals, rs=1000, b0=0.1, alpha=-1.0) :
@@ -63,7 +62,6 @@ def compute_powerlaw_boost(rvals, rs=1000, b0=0.1, alpha=-1.0) :
 
     return 1. + b0 * (x)**alpha
 
-    
 
 boost_models = {'nfw_boost': compute_nfw_boost,
                 'powerlaw_boost': compute_powerlaw_boost}
@@ -103,7 +101,6 @@ def correct_sigma_with_boost_model(rvals, sigma_vals, boost_model='nfw_boost', *
         Boost model to use for correcting sigma
             `nfw_boost` - NFW profile model (Default)
             `powerlaw_boost` - Powerlaw profile
-    
 
     Returns
     -------
@@ -605,13 +602,13 @@ def compute_for_good_redshifts(function, z1, z2, bad_value, error_message):
     return res
 
 def compute_beta(z_s, z_cl, cosmo):
-    r"""Geometric lensing efficicency  
-    
-    .. math:: 
+    r"""Geometric lensing efficicency
+
+    .. math::
         beta = max(0, Dang_ls/Dang_s)
-        
-    Eq.2 in https://arxiv.org/pdf/1611.03866.pdf    
-    
+
+    Eq.2 in https://arxiv.org/pdf/1611.03866.pdf
+
     Parameters
     ----------
     z_cl: float
@@ -620,7 +617,7 @@ def compute_beta(z_s, z_cl, cosmo):
             Source galaxy  redshift
     cosmo: Cosmology
         Cosmology object
-    
+
     Returns
     -------
     float
@@ -630,9 +627,9 @@ def compute_beta(z_s, z_cl, cosmo):
     return beta
 
 def compute_beta_s(z_s, z_cl, z_inf, cosmo):
-    r"""Geometric lensing efficicency ratio 
-    
-    .. math:: 
+    r"""Geometric lensing efficicency ratio
+
+    .. math::
         beta_s =beta(z_s)/beta(z_inf)
 
     Parameters
@@ -645,7 +642,7 @@ def compute_beta_s(z_s, z_cl, z_inf, cosmo):
             Redshift at infinity
     cosmo: Cosmology
         Cosmology object
-    
+
     Returns
     -------
     float
@@ -655,9 +652,9 @@ def compute_beta_s(z_s, z_cl, z_inf, cosmo):
     return beta_s
 
 def compute_beta_mean(z_cl, cosmo, zmax=10.0, delta_z_cut=0.1, zmin=None, z_distrib_func=None):
-    r"""Mean value of the geometric lensing efficicency  
-    
-    .. math:: 
+    r"""Mean value of the geometric lensing efficicency
+
+    .. math::
        \left\<beta\right\> =\frac{\sum_{z = z_{min}}^{z = z_{max}}\beta(z)p(z)}{\sum_{z = z_{min}}^{z = z_{max}}p(z)}
 
     Parameters
@@ -681,7 +678,7 @@ def compute_beta_mean(z_cl, cosmo, zmax=10.0, delta_z_cut=0.1, zmin=None, z_dist
             $zmin$. This feature is not used if $z_min$ is provided by the user.
     cosmo: Cosmology
         Cosmology object
-    
+
     Returns
     -------
     float
@@ -691,17 +688,17 @@ def compute_beta_mean(z_cl, cosmo, zmax=10.0, delta_z_cut=0.1, zmin=None, z_dist
         z_distrib_func = _chang_z_distrib
     def integrand(z_i, z_cl=z_cl, cosmo=cosmo):
         return compute_beta(z_i, z_cl, cosmo) * z_distrib_func(z_i)
-    
+
     if zmin==None:
         zmin = z_cl + delta_z_cut
-    
+
     B_mean = quad(integrand, zmin, zmax)[0] / quad(z_distrib_func, zmin, zmax)[0]
     return B_mean    
 
 def compute_beta_s_mean(z_cl, z_inf, cosmo, zmax=10.0, delta_z_cut=0.1, zmin=None, z_distrib_func=None):
-    r"""Mean value of the geometric lensing efficicency ratio 
-    
-    .. math:: 
+    r"""Mean value of the geometric lensing efficicency ratio
+
+    .. math::
        \left\<beta_s\right\> =\frac{\sum_{z = z_{min}}^{z = z_{max}}\beta_s(z)p(z)}{\sum_{z = z_{min}}^{z = z_{max}}p(z)}
 
     Parameters
@@ -725,12 +722,12 @@ def compute_beta_s_mean(z_cl, z_inf, cosmo, zmax=10.0, delta_z_cut=0.1, zmin=Non
             $zmin$. This feature is not used if $z_min$ is provided by the user.
     cosmo: Cosmology
         Cosmology object
-    
+
     Returns
     -------
     float
         Mean value of the geometric lensing efficicency ratio
-    """   
+    """
     if z_distrib_func == None:
         z_distrib_func = _chang_z_distrib
 
@@ -743,9 +740,9 @@ def compute_beta_s_mean(z_cl, z_inf, cosmo, zmax=10.0, delta_z_cut=0.1, zmin=Non
     return Bs_mean
 
 def compute_beta_s_square_mean(z_cl, z_inf, cosmo, zmax=10.0, delta_z_cut=0.1, zmin=None, z_distrib_func=None):
-    r"""Mean square value of the geometric lensing efficicency ratio 
-    
-    .. math:: 
+    r"""Mean square value of the geometric lensing efficicency ratio
+
+    .. math::
        \left\<beta_s\right\>2 =\frac{\sum_{z = z_{min}}^{z = z_{max}}\beta_s^2(z)p(z)}{\sum_{z = z_{min}}^{z = z_{max}}p(z)}
 
     Parameters
@@ -769,18 +766,18 @@ def compute_beta_s_square_mean(z_cl, z_inf, cosmo, zmax=10.0, delta_z_cut=0.1, z
             $zmin$. This feature is not used if $z_min$ is provided by the user.
     cosmo: Cosmology
         Cosmology object
-    
+
     Returns
     -------
     float
         Mean square value of the geometric lensing efficicency ratio.
-    """ 
+    """
     if z_distrib_func == None:
         z_distrib_func = _chang_z_distrib
-    
+
     def integrand(z_i, z_cl=z_cl, z_inf=z_inf, cosmo=cosmo):
         return compute_beta_s(z_i, z_cl, z_inf, cosmo)**2 * z_distrib_func(z_i)
-    
+
     if zmin==None:
         zmin = z_cl + delta_z_cut
     Bs_square_mean = quad(integrand, zmin, zmax)[0] / quad(z_distrib_func, zmin, zmax)[0]

--- a/tests/test_cosmo_parent.py
+++ b/tests/test_cosmo_parent.py
@@ -39,9 +39,9 @@ def test_class(modeling_data):
     assert_raises(AttributeError, CLMMCosmology.set_be_cosmo, None, None)
     assert_raises(NotImplementedError, CLMMCosmology._get_Omega_m, None, None)
     assert_raises(NotImplementedError,
-                  CLMMCosmology._eval_da_z1z2, None, None, None)
+                  CLMMCosmology._eval_da_z1z2_core, None, None, None)
     assert_raises(NotImplementedError,
-                  CLMMCosmology._eval_sigma_crit, None, None, None)
+                  CLMMCosmology._eval_sigma_crit_core, None, None, None)
     assert_raises(NotImplementedError, CLMMCosmology._get_E2Omega_m, None, None)
     assert_raises(NotImplementedError,
                   CLMMCosmology._eval_linear_matter_powerspectrum, None, None, None)

--- a/tests/test_cosmo_parent.py
+++ b/tests/test_cosmo_parent.py
@@ -149,6 +149,9 @@ def test_cosmo_basic(modeling_data, cosmo_init):
     assert_allclose(cosmo.eval_da_a1a2(testcase['aexp_source'],
                                        testcase['aexp_cluster']),
                     testcase['dsl'], reltol)
+    assert_allclose(cosmo.eval_da_a1a2(testcase['aexp_source'],
+                                       [testcase['aexp_cluster']]*5),
+                    np.array([testcase['dsl']]*5), reltol)
 
     # Test initializing cosmo
     theo.Cosmology(be_cosmo=cosmo.be_cosmo)

--- a/tests/test_cosmo_parent.py
+++ b/tests/test_cosmo_parent.py
@@ -151,7 +151,7 @@ def test_cosmo_basic(modeling_data, cosmo_init):
                     testcase['dsl'], reltol)
     assert_allclose(cosmo.eval_da_a1a2(testcase['aexp_source'],
                                        [testcase['aexp_cluster']]*5),
-                    np.array([testcase['dsl']]*5), reltol)
+                    [testcase['dsl']]*5, reltol)
 
     # Test initializing cosmo
     theo.Cosmology(be_cosmo=cosmo.be_cosmo)

--- a/tests/test_cosmo_parent.py
+++ b/tests/test_cosmo_parent.py
@@ -140,6 +140,8 @@ def test_cosmo_basic(modeling_data, cosmo_init):
     assert_allclose(cosmo.eval_da(z), cosmo.eval_da_z1z2(0.0, z), rtol=8.0e-15)
     assert_allclose(cosmo.eval_da_z1z2(0.0, z),
                     cosmo.eval_da_z1z2(0.0, z), rtol=8.0e-15)
+    assert_allclose(cosmo.eval_da_z1z2(0.0, z),
+                    -cosmo.eval_da_z1z2(z, 0.0)/(1+z), rtol=8.0e-15)
     # Test da(a1, a1)
     cosmo, testcase, _ = load_validation_config()
     assert_allclose(cosmo.eval_da_a1a2(testcase['aexp_cluster']),

--- a/tests/test_cosmo_parent.py
+++ b/tests/test_cosmo_parent.py
@@ -140,8 +140,6 @@ def test_cosmo_basic(modeling_data, cosmo_init):
     assert_allclose(cosmo.eval_da(z), cosmo.eval_da_z1z2(0.0, z), rtol=8.0e-15)
     assert_allclose(cosmo.eval_da_z1z2(0.0, z),
                     cosmo.eval_da_z1z2(0.0, z), rtol=8.0e-15)
-    assert_allclose(cosmo.eval_da_z1z2(0.0, z),
-                    -cosmo.eval_da_z1z2(z, 0.0)/(1+z), rtol=8.0e-15)
     # Test da(a1, a1)
     cosmo, testcase, _ = load_validation_config()
     assert_allclose(cosmo.eval_da_a1a2(testcase['aexp_cluster']),


### PR DESCRIPTION
Make _eval_da_z1z2 for CCL backend behave the same way as for the other two backends. Though many lines of code are added, it is still faster than the original numpy.vectorize implementation. 