### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -8,15 +8,14 @@ on:
 
 jobs:
   build-gcc-ubuntu:
-    # cluster-toolkit cannot find libffi.so.8 in the latest Ubuntu, so stay on Ubuntu 20.04 for now
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
     - uses: conda-incubator/setup-miniconda@v2
     - name: Install prereq using conda
       run: |
-        conda install -c conda-forge gobject-introspection pygobject python_abi=3.9=3_cp39
+        conda install -c conda-forge gobject-introspection pygobject python_abi=3.9=3_cp39 cffi=1.15.1
         echo "$CONDA/bin" >> $GITHUB_PATH
     - name: Install prereq using pip
       run: |

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
     - name: Install prereq using conda
       run: |
-        conda install -c conda-forge gobject-introspection pygobject openssl=3 -y
+        conda install -c conda-forge gobject-introspection pygobject python_abi=3.9=3_cp39.conda
         echo "$CONDA/bin" >> $GITHUB_PATH
     - name: Install prereq using pip
       run: |
@@ -26,7 +26,7 @@ jobs:
         pip install .
     - name: Install NumCosmo from conda-forge
       run: |
-        conda install -c conda-forge numcosmo -y
+        conda install -c conda-forge numcosmo
     - name: Install cluster_toolkit from source
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git
@@ -34,7 +34,7 @@ jobs:
         pip install .
     - name: Install CCL from source
       run: |
-        conda install -c conda-forge cmake swig -y
+        conda install -c conda-forge cmake swig
         git clone https://github.com/LSSTDESC/CCL
         cd CCL
         pip install .

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'issue/gh_actions'
   pull_request:
 
 jobs:

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: conda-incubator/setup-miniconda@v2
     - name: Install prereq using conda
       run: |
-        conda install -c conda-forge gobject-introspection pygobject -y
+        conda install -c conda-forge gobject-introspection pygobject openssl -y
         echo "$CONDA/bin" >> $GITHUB_PATH
     - name: Install prereq using pip
       run: |

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: actions/checkout@v3
+    - uses: conda-incubator/setup-miniconda@v2
     - name: Install prereq using conda
       run: |
         conda install -c conda-forge gobject-introspection pygobject python_abi=3.9=2_cp39 -y

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -14,17 +14,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
     - name: Install prereq using conda
       run: |
-        conda install -c conda-forge gobject-introspection pygobject libffi python_abi=3.9=2_cp39 -y
+        conda install -c conda-forge gobject-introspection pygobject python_abi=3.9=2_cp39 -y
         echo "$CONDA/bin" >> $GITHUB_PATH
+        find $CONDA/lib -name "libffi.so*"
+        ln -s $CONDA/lib/libffi.so.6* $CONDA/lib/libffi.so.7
     - name: Install prereq using pip
       run: |
         pip install -r requirements.txt
     - name: Install the package
       run: |
-        python setup.py install
+        pip install .
     - name: Install NumCosmo from conda-forge
       run: |
         conda install -c conda-forge numcosmo -y
@@ -32,13 +34,13 @@ jobs:
       run: |
         git clone https://github.com/tmcclintock/cluster_toolkit.git
         cd cluster_toolkit
-        python setup.py install
+        pip install .
     - name: Install CCL from source
       run: |
         conda install -c conda-forge cmake swig -y
         git clone https://github.com/LSSTDESC/CCL
         cd CCL
-        python setup.py install
+        pip install .
     - name: Run the unit tests
       run: |
         pip install pytest pytest-cov

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
     - name: Install prereq using conda
       run: |
-        conda install -c conda-forge gobject-introspection pygobject openssl -y
+        conda install -c conda-forge gobject-introspection pygobject openssl=3 -y
         echo "$CONDA/bin" >> $GITHUB_PATH
     - name: Install prereq using pip
       run: |

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2
     - name: Install prereq using conda
       run: |

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
     - name: Install prereq using conda
       run: |
-        conda install -c conda-forge gobject-introspection pygobject libffi=3.3 python_abi=3.9=2_cp39 -y
+        conda install -c conda-forge gobject-introspection pygobject libffi=3.4.2 -y
         echo "$CONDA/bin" >> $GITHUB_PATH
     - name: Install prereq using pip
       run: |

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
     - name: Install prereq using conda
       run: |
-        conda install -c conda-forge gobject-introspection pygobject python_abi=3.9=3_cp39.conda
+        conda install -c conda-forge gobject-introspection pygobject python_abi=3.9=3_cp39
         echo "$CONDA/bin" >> $GITHUB_PATH
     - name: Install prereq using pip
       run: |

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
     - name: Install prereq using conda
       run: |
-        conda install -c conda-forge gobject-introspection pygobject libffi=3.3 -y
+        conda install -c conda-forge gobject-introspection pygobject libffi=3.3 python_abi=3.9=2_cp39 -y
         echo "$CONDA/bin" >> $GITHUB_PATH
     - name: Install prereq using pip
       run: |

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-gcc-ubuntu:
-
+    # cluster-toolkit cannot find libffi.so.8 in the latest Ubuntu, so stay on Ubuntu 20.04 for now
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -10,14 +10,14 @@ on:
 jobs:
   build-gcc-ubuntu:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3
     - uses: conda-incubator/setup-miniconda@v2
     - name: Install prereq using conda
       run: |
-        conda install -c conda-forge gobject-introspection pygobject libffi=3.4.2 -y
+        conda install -c conda-forge gobject-introspection pygobject -y
         echo "$CONDA/bin" >> $GITHUB_PATH
     - name: Install prereq using pip
       run: |

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'gh_actions'
   pull_request:
 
 jobs:
@@ -16,7 +17,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
     - name: Install prereq using conda
       run: |
-        conda install -c conda-forge gobject-introspection pygobject python_abi=3.9=2_cp39 -y
+        conda install -c conda-forge gobject-introspection pygobject libffi python_abi=3.9=2_cp39 -y
         echo "$CONDA/bin" >> $GITHUB_PATH
     - name: Install prereq using pip
       run: |

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: '3.10'
     - name: Install prereq using conda
       run: |
         conda install -c conda-forge gobject-introspection pygobject libffi=3.3 -y

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -19,8 +19,7 @@ jobs:
       run: |
         conda install -c conda-forge gobject-introspection pygobject python_abi=3.9=2_cp39 -y
         echo "$CONDA/bin" >> $GITHUB_PATH
-        find $CONDA/lib -name "libffi.so*"
-        ln -s $CONDA/lib/libffi.so.6* $CONDA/lib/libffi.so.7
+        ln -s $CONDA/lib/libffi.so $CONDA/lib/libffi.so.7
     - name: Install prereq using pip
       run: |
         pip install -r requirements.txt

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - '*gh_actions'
+      - 'issue/gh_actions'
   pull_request:
 
 jobs:

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - 'gh_actions'
+      - '*gh_actions'
   pull_request:
 
 jobs:

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -15,11 +15,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: conda-incubator/setup-miniconda@v2
+      with:
+        python-version: '3.10'
     - name: Install prereq using conda
       run: |
-        conda install -c conda-forge gobject-introspection pygobject python_abi=3.9=2_cp39 -y
+        conda install -c conda-forge gobject-introspection pygobject libffi=3.3 -y
         echo "$CONDA/bin" >> $GITHUB_PATH
-        ln -s $CONDA/lib/libffi.so $CONDA/lib/libffi.so.7
     - name: Install prereq using pip
       run: |
         pip install -r requirements.txt

--- a/clmm/__init__.py
+++ b/clmm/__init__.py
@@ -15,4 +15,4 @@ from .theory import (
 )
 from . import support
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'


### PR DESCRIPTION
1. Use `ubuntu-20.04` instead of `ubuntu-latest`, which now refers to Ubuntu 22.04 (was 20.04)
2. Use `actions/checkout@v3` because Node.js 12 (from v2) actions are deprecated according to the warning from GitHub Actions
3. Use `pip install .` instead of `python setup.py install`, which is deprecated
4. `-y` is issued automatically throughout, so we can drop it in the script