### PR TITLE
Fix CCL 2.6.2-dev7 

### DIFF
--- a/clmm/__init__.py
+++ b/clmm/__init__.py
@@ -15,4 +15,4 @@ from .theory import (
 )
 from . import support
 
-__version__ = '1.5.6'
+__version__ = '1.5.7'

--- a/clmm/theory/ccl.py
+++ b/clmm/theory/ccl.py
@@ -87,7 +87,8 @@ class CCLCLMModeling(CLMModeling):
 
             self.mdef = ccl.halos.MassDef(delta_mdef, self.mdef_dict[massdef])
             self.conc = ccl.halos.ConcentrationConstant(c=cdelta, mdef=self.mdef)
-            self.mdef.concentration = self.conc
+            with ccl.UnlockInstance(self.mdef):
+                self.mdef.concentration = self.conc
             self.hdpm = self.hdpm_dict[halo_profile_model](
                 self.conc, **self.hdpm_opts[halo_profile_model])
             self.hdpm.update_precision_fftlog(padding_lo_fftlog=1e-4,
@@ -104,7 +105,8 @@ class CCLCLMModeling(CLMModeling):
 
     def _set_concentration(self, cdelta):
         """" set concentration"""
-        self.conc.c = cdelta
+        with ccl.UnlockInstance(self.conc):
+            self.conc.c = cdelta
 
     def _set_mass(self, mdelta):
         """" set mass"""

--- a/clmm/theory/ccl.py
+++ b/clmm/theory/ccl.py
@@ -7,6 +7,7 @@ import pyccl as ccl
 
 import numpy as np
 from scipy.interpolate import interp1d
+from packaging.version import parse
 
 from . import func_layer
 from . func_layer import *
@@ -87,7 +88,10 @@ class CCLCLMModeling(CLMModeling):
 
             self.mdef = ccl.halos.MassDef(delta_mdef, self.mdef_dict[massdef])
             self.conc = ccl.halos.ConcentrationConstant(c=cdelta, mdef=self.mdef)
-            with ccl.UnlockInstance(self.mdef):
+            if parse(ccl.__version__) >= parse('2.6.2dev7'):
+                with ccl.UnlockInstance(self.mdef):
+                    self.mdef.concentration = self.conc
+            else:
                 self.mdef.concentration = self.conc
             self.hdpm = self.hdpm_dict[halo_profile_model](
                 self.conc, **self.hdpm_opts[halo_profile_model])
@@ -105,7 +109,10 @@ class CCLCLMModeling(CLMModeling):
 
     def _set_concentration(self, cdelta):
         """" set concentration"""
-        with ccl.UnlockInstance(self.conc):
+        if parse(ccl.__version__) >= parse('2.6.2dev7'):
+            with ccl.UnlockInstance(self.conc):
+                self.conc.c = cdelta
+        else:
             self.conc.c = cdelta
 
     def _set_mass(self, mdelta):

--- a/clmm/theory/cluster_toolkit.py
+++ b/clmm/theory/cluster_toolkit.py
@@ -95,8 +95,8 @@ class CTModeling(CLMModeling):
     # Functions implemented by child class
 
 
-    def _set_halo_density_profile(self, halo_profile_model='nfw', massdef='mean', delta_mdef=200):
-        """"set halo density profile"""
+    def _update_halo_density_profile(self):
+        """"updates halo density profile with set internal properties"""
         pass
 
     def _get_concentration(self):

--- a/clmm/theory/numcosmo.py
+++ b/clmm/theory/numcosmo.py
@@ -75,25 +75,20 @@ class NumCosmoCLMModeling(CLMModeling):
         self.cosmo.smd = Nc.WLSurfaceMassDensity.new(self.cosmo.dist)
         self.cosmo.smd.prepare_if_needed(self.cosmo.be_cosmo)
 
-    def _set_halo_density_profile(self, halo_profile_model='nfw', massdef='mean', delta_mdef=200):
-        """"set halo density profile"""
-        # Check if we have already an instance of the required object, if not create one
-        if not((halo_profile_model==self.halo_profile_model)
-                and (massdef==self.massdef)
-                and (delta_mdef==self.delta_mdef)):
+    def _update_halo_density_profile(self):
+        """"updates halo density profile with set internal properties"""
+        # Makes sure current cdelta/mdelta values are kept
+        has_cm_vals = self.hdpm is not None
+        if has_cm_vals:
+            cdelta = self.cdelta
+            log10_mdelta = self.hdpm.props.log10MDelta
 
-            # Makes sure current cdelta/mdelta values are kept
-            has_cm_vals = self.hdpm is not None
-            if has_cm_vals:
-                cdelta = self.cdelta
-                log10_mdelta = self.hdpm.props.log10MDelta
+        self.hdpm = self.hdpm_dict[self.halo_profile_model](
+            self.mdef_dict[self.massdef], self.delta_mdef)
 
-            self.hdpm = self.hdpm_dict[halo_profile_model](
-                self.mdef_dict[massdef], delta_mdef)
-
-            if has_cm_vals:
-                self.cdelta = cdelta
-                self.hdpm.props.log10MDelta = log10_mdelta
+        if has_cm_vals:
+            self.cdelta = cdelta
+            self.hdpm.props.log10MDelta = log10_mdelta
 
     def _get_concentration(self):
         """"get concentration"""

--- a/clmm/theory/parent_class.py
+++ b/clmm/theory/parent_class.py
@@ -142,7 +142,7 @@ class CLMModeling:
         r""" Actuall sets the value of the concentration (without value check)"""
         raise NotImplementedError
 
-    def _set_halo_density_profile(self, halo_profile_model='nfw', massdef='mean', delta_mdef=200):
+    def _update_halo_density_profile(self):
         raise NotImplementedError
 
     def _set_einasto_alpha(self, alpha):
@@ -337,14 +337,20 @@ class CLMModeling:
             if not halo_profile_model in self.hdpm_dict:
                 raise ValueError(
                     f"Halo density profile model {halo_profile_model} not currently supported")
-        # set the profile
-        self._set_halo_density_profile(halo_profile_model=halo_profile_model,
-                                       massdef=massdef, delta_mdef=delta_mdef)
+        # Check if we have already an instance of the required object, if not create one
+        if (
+                (self.hdpm is None)
+                or (self.halo_profile_model!=halo_profile_model)
+                or (self.massdef!=massdef)
+                or (self.delta_mdef!=delta_mdef)
+        ):
+            # set internal quantities
+            self.__halo_profile_model = halo_profile_model
+            self.__massdef = massdef
+            self.__delta_mdef = delta_mdef
+            # set the profile
+            self._update_halo_density_profile()
 
-        # set internal quantities
-        self.__halo_profile_model = halo_profile_model
-        self.__massdef = massdef
-        self.__delta_mdef = delta_mdef
 
     def set_einasto_alpha(self, alpha):
         r""" Sets the value of the :math:`\alpha` parameter for the Einasto profile

--- a/tests/test_theory_parent.py
+++ b/tests/test_theory_parent.py
@@ -17,7 +17,7 @@ def test_unimplemented(modeling_data):
     assert_raises(NotImplementedError, mod._set_mass, 1.0e15)
     assert_raises(NotImplementedError, mod.set_concentration, 4.0)
     assert_raises(NotImplementedError, mod._set_concentration, 4.0)
-    assert_raises(NotImplementedError, mod._set_halo_density_profile)
+    assert_raises(NotImplementedError, mod._update_halo_density_profile)
     assert_raises(NotImplementedError, mod._set_einasto_alpha, 0.5)
     assert_raises(NotImplementedError, mod._get_einasto_alpha)
     assert_raises(NotImplementedError, mod.eval_3d_density, [0.3], 0.3)


### PR DESCRIPTION
Now CCL only allows modifying class attributes by public functions. To fix instantiating a modeling object, we will need to call either `ccl.UnlockInstance` or  `__init__` again.