### PR TITLE
issue/630/add environment.yml

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,6 +64,17 @@ Now, you can install CLMM and its dependencies as
     python setup.py install     # build from source
 ```
 
+### Local environment for CLMM
+
+Alternatively, you can create a new local environment and install CLMM by running
+
+```bash
+    conda env create -f environment.yml
+    conda activate clmm
+```
+
+You can now install CLMM in a local and stable environment with the usual procedure.
+
 ## Access to the proper environment on cori.nersc.gov <a name="access_to_the_proper_environment_on_cori"></a>
 
 If you have access to NERSC, this will likely be the easiest to make sure you have the appropriate environment.  After logging into cori.nersc.gov, you will need to execute the following.  We recommend executing line-by-line to avoid errors:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,7 +66,7 @@ Now, you can install CLMM and its dependencies as
 
 ### Local environment for CLMM
 
-Alternatively, you can create a new local environment and install CLMM by running
+Alternatively, you can create a new local environment by running
 
 ```bash
     conda env create -f environment.yml

--- a/clmm/__init__.py
+++ b/clmm/__init__.py
@@ -26,4 +26,4 @@ from .theory import (
 )
 from . import support
 
-__version__ = "1.13.0"
+__version__ = "1.13.1"

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,19 @@
+# CLMM Conda environment
+name: clmm
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python==3.10.2
+  - pip>=21.0
+  - jupyter>=1.0
+  - numpy==1.25.2
+  - scipy==1.11.2
+  - astropy==5.3.2
+  - matplotlib==3.7.2
+  - gsl==2.7
+  - cmake==3.30.0
+  - pyccl==3.0
+  - numcosmo==0.18.2
+  - pytest=7.4.0
+  - sphinx==7.2.4

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - numpy==1.25.2
   - scipy==1.11.2
   - astropy==5.3.2
+  - healpy == 1.16.5
   - matplotlib==3.7.2
   - gsl==2.7
   - cmake==3.30.0


### PR DESCRIPTION
This PR addresses#630 . A new file, `environment.yml`, is created to allow users to work locally in a stable and fixed conda environment by running:
```bash
$ conda env create -f environment.yml
$ conda activate clmm
```