### PR TITLE
add version check to the CI [version:1.16.6]

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Get version from current branch
         id: current_version
         run: |
-          CURRENT_VERSION="$(grep -oP '__version__ = "\K[^"]+' crow/__init__.py)"
+          CURRENT_VERSION="$(grep -oP '__version__ = "\K[^"]+' clmm/__init__.py)"
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
       # Get main version
       - name: Checkout the main branch to get its version
@@ -101,8 +101,8 @@ jobs:
       - name: Get version from main branch
         id: main_version
         run: |
-          if [[ "$(git show origin/main:crow/__init__.py)" == *"__version__"* ]]; then
-            MAIN_VERSION="$(grep -oP '__version__ = "\K[^"]+' crow/__init__.py)"
+          if [[ "$(git show origin/main:clmm/__init__.py)" == *"__version__"* ]]; then
+            MAIN_VERSION="$(grep -oP '__version__ = "\K[^"]+' clmm/__init__.py)"
           else
             echo "No version found at main, assuming version 0.0.0"
             MAIN_VERSION="0.0.0"
@@ -128,7 +128,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "$CURRENT_VERSION" == "$MAIN_VERSION" ]; then
-            echo "Version at crow/__init__.py has not been updated!"
+            echo "Version at clmm/__init__.py has not been updated!"
             # Use the GitHub API to update the PR title
             echo "Removing version from PR title: $NEW_TITLE"
             update_pr_title $NEW_TITLE

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -75,16 +75,6 @@ jobs:
     name: Verify code version update
     runs-on: ubuntu-latest
     steps:
-      - name: Set up the title updater function
-        run: |
-          # Define a function for the repeated operation
-          update_pr_title() {
-            curl -s -X PATCH \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              -H "Accept: application/vnd.github.v3+json" \
-              -d "{\"title\":\"$1\"}" \
-              "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" > /dev/null
-          }
       # Get current version
       - name: Check out the code
         uses: actions/checkout@v4
@@ -131,7 +121,11 @@ jobs:
             echo "Version at clmm/__init__.py has not been updated!"
             # Use the GitHub API to update the PR title
             echo "Removing version from PR title: $NEW_TITLE"
-            update_pr_title $NEW_TITLE
+            curl -s -X PATCH \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -d "{\"title\":\"$NEW_TITLE\"}" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" > /dev/null
             exit 1
           fi
           echo "[ok] Version has changed!"
@@ -143,7 +137,11 @@ jobs:
             echo "Current version ($CURRENT_VERSION) < Main version ($MAIN_VERSION)"
             # Use the GitHub API to update the PR title
             echo "Removing version from PR title: $NEW_TITLE"
-            update_pr_title $NEW_TITLE
+            curl -s -X PATCH \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -d "{\"title\":\"$NEW_TITLE\"}" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" > /dev/null
             exit 1
           fi
           echo "[ok] Version increased changed!"
@@ -159,4 +157,8 @@ jobs:
         run: |
           # Use the GitHub API to update the PR title
           echo "Updating PR #$PR_NUMBER with new title: $NEW_TITLE"
-          update_pr_title $NEW_TITLE
+          curl -s -X PATCH \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d "{\"title\":\"$NEW_TITLE\"}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" > /dev/null

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -75,7 +75,7 @@ jobs:
     name: Verify code version update
     runs-on: ubuntu-latest
     steps:
-    - name: Set up the title updater function
+      - name: Set up the title updater function
         run: |
           # Define a function for the repeated operation
           update_pr_title() {

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -70,3 +70,93 @@ jobs:
       run: |
         pip install coveralls
         coveralls --service=github
+
+  check-code-version:
+    name: Verify code version update
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up the title updater function
+        run: |
+          # Define a function for the repeated operation
+          update_pr_title() {
+            curl -s -X PATCH \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -d "{\"title\":\"$1\"}" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" > /dev/null
+          }
+      # Get current version
+      - name: Check out the code
+        uses: actions/checkout@v4
+      - name: Get version from current branch
+        id: current_version
+        run: |
+          CURRENT_VERSION="$(grep -oP '__version__ = "\K[^"]+' crow/__init__.py)"
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+      # Get main version
+      - name: Checkout the main branch to get its version
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Get version from main branch
+        id: main_version
+        run: |
+          if [[ "$(git show origin/main:crow/__init__.py)" == *"__version__"* ]]; then
+            MAIN_VERSION="$(grep -oP '__version__ = "\K[^"]+' crow/__init__.py)"
+          else
+            echo "No version found at main, assuming version 0.0.0"
+            MAIN_VERSION="0.0.0"
+          fi
+          echo "MAIN_VERSION=$MAIN_VERSION" >> $GITHUB_ENV
+      # Get PR title to be updated with version
+      - name : Get PR title and clean version number from it
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          NEW_TITLE="${TITLE% [version:*}"
+          echo "New title: $NEW_TITLE"
+          echo "NEW_TITLE=$NEW_TITLE" >> $GITHUB_ENV
+      - name: Get PR number
+        id: pr_number
+        run: |
+          # Fetch the pull request number from the GitHub context
+          PR_NUMBER=$(echo $GITHUB_REF | sed 's/refs\/pull\/\([0-9]*\)\/merge/\1/')
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+      # Compare
+      - name: Check version change
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$CURRENT_VERSION" == "$MAIN_VERSION" ]; then
+            echo "Version at crow/__init__.py has not been updated!"
+            # Use the GitHub API to update the PR title
+            echo "Removing version from PR title: $NEW_TITLE"
+            update_pr_title $NEW_TITLE
+            exit 1
+          fi
+          echo "[ok] Version has changed!"
+      - name: Check version update
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$(printf "%s\n%s" "$CURRENT_VERSION" "$MAIN_VERSION" | sort -V | tail -n 1)" != "$CURRENT_VERSION" ]; then
+            echo "Current version ($CURRENT_VERSION) < Main version ($MAIN_VERSION)"
+            # Use the GitHub API to update the PR title
+            echo "Removing version from PR title: $NEW_TITLE"
+            update_pr_title $NEW_TITLE
+            exit 1
+          fi
+          echo "[ok] Version increased changed!"
+      # Add version number to PR title
+      - name : Make new title for PR
+        run: |
+          NEW_TITLE="${NEW_TITLE} [version:$CURRENT_VERSION]"
+          echo "New title: $NEW_TITLE"
+          echo "NEW_TITLE=$NEW_TITLE" >> $GITHUB_ENV
+      - name: Update PR title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Use the GitHub API to update the PR title
+          echo "Updating PR #$PR_NUMBER with new title: $NEW_TITLE"
+          update_pr_title $NEW_TITLE

--- a/clmm/__init__.py
+++ b/clmm/__init__.py
@@ -27,4 +27,4 @@ from .theory import (
 )
 from .utils import compute_radial_averages, convert_units, make_bins
 
-__version__ = "1.16.5"
+__version__ = "1.16.6"


### PR DESCRIPTION
## Description

Add check version to the CI

## Main changes
<!-- List the major changes in this PR-->
- CI test fails if version is not updated
- Adds code version in PR title

## Checklist

Besides passing all CI checks and coverage is at 100%, make sure you also checked the following items
(check details in [CONTRIBUTING](https://github.com/LSSTDESC/CLMM/blob/main/CONTRIBUTING.md)).

### For developers

- [ ] **Notebooks:** notebooks related to this PR have been updated and all notebooks can run correctly.
- [ ] **Build the documentation:** All documentation builds correctly.

### For reviewers

- [x] **Notebooks:** notebooks related to this PR have been updated and all notebooks can run correctly.
- [x] **Build the documentation:** All documentation builds correctly.

### For developers (part 2)

After the PR has been approved by two reviewers:

- [x] Update the code version in `clmm/__ini__.py`.
- [x] Keep only relevant points in the squash and merge commit message.
