### PR TITLE
Issue/687/cosmo pub calls [version:1.16.8]

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install prereq and NumCosmo using conda
       run: |
         echo "$CONDA/bin" >> $GITHUB_PATH
-        conda install -c conda-forge gobject-introspection pygobject 'numcosmo<=0.22.0' cmake swig setuptools_scm sphinx sphinx_rtd_theme nbconvert pandoc ipython
+        conda install -c conda-forge gobject-introspection pygobject 'numcosmo<=0.22.0' cmake swig setuptools_scm sphinx=8.2.3 sphinx_rtd_theme nbconvert pandoc ipython
     - name: Install prereq using pip
       run: |
         pip install -r requirements.txt
@@ -68,7 +68,7 @@ jobs:
     - name: Install prereq and NumCosmo using conda
       run: |
         echo "$CONDA/bin" >> $GITHUB_PATH
-        conda install -c conda-forge gobject-introspection pygobject 'numcosmo<=0.22.0' cmake swig setuptools_scm sphinx sphinx_rtd_theme nbconvert pandoc ipython
+        conda install -c conda-forge gobject-introspection pygobject 'numcosmo<=0.22.0' cmake swig setuptools_scm
     - name: Install prereq using pip
       run: |
         pip install -r requirements.txt

--- a/clmm/__init__.py
+++ b/clmm/__init__.py
@@ -27,4 +27,4 @@ from .theory import (
 )
 from .utils import compute_radial_averages, convert_units, make_bins
 
-__version__ = "1.16.7"
+__version__ = "1.16.8"

--- a/clmm/theory/parent_class.py
+++ b/clmm/theory/parent_class.py
@@ -82,12 +82,19 @@ class CLMModeling:
         self.mdef_dict = {}
         self.hdpm_dict = {}
 
-        self.validate_input = validate_input
         self.cosmo_class = lambda *args: None
 
         self.z_inf = z_inf
+        self.__validate_input = True
+        self.validate_input = validate_input
+
 
     # 1. Object properties
+
+    @property
+    def validate_input(self):
+        """Mass of cluster"""
+        return self.__validate_input
 
     @property
     def mdelta(self):
@@ -115,6 +122,13 @@ class CLMModeling:
         return self.__halo_profile_model
 
     # 1.a Object properties setter
+
+    @validate_input.setter
+    def validate_input(self, validate_input):
+        """Mass of cluster"""
+        self.__validate_input = validate_input
+        if self.cosmo is not None:
+            self.cosmo.validate_input = validate_input
 
     @mdelta.setter
     def mdelta(self, mdelta):

--- a/clmm/theory/parent_class.py
+++ b/clmm/theory/parent_class.py
@@ -92,7 +92,7 @@ class CLMModeling:
 
     @property
     def validate_input(self):
-        """Mass of cluster"""
+        """Input format check"""
         return self.__validate_input
 
     @property
@@ -124,7 +124,7 @@ class CLMModeling:
 
     @validate_input.setter
     def validate_input(self, validate_input):
-        """Mass of cluster"""
+        """Set input format check"""
         self.__validate_input = validate_input
         if self.cosmo is not None:
             self.cosmo.validate_input = validate_input

--- a/clmm/theory/parent_class.py
+++ b/clmm/theory/parent_class.py
@@ -88,7 +88,6 @@ class CLMModeling:
         self.__validate_input = True
         self.validate_input = validate_input
 
-
     # 1. Object properties
 
     @property
@@ -218,10 +217,6 @@ class CLMModeling:
         raise NotImplementedError
 
     # 3. Functions that can be used by all subclasses
-
-    def _set_cosmo(self, cosmo):
-        r"""Sets the cosmology to the internal cosmology object"""
-        self.cosmo = cosmo if cosmo is not None else self.cosmo_class()
 
     def _eval_2halo_term_generic(
         self,
@@ -505,7 +500,7 @@ class CLMModeling:
             if self.cosmo_class() is None:
                 raise NotImplementedError
             validate_argument(locals(), "cosmo", self.cosmo_class, none_ok=True)
-        self._set_cosmo(cosmo)
+        self.cosmo = cosmo if cosmo is not None else self.cosmo_class()
         self.cosmo.validate_input = self.validate_input
 
     def set_halo_density_profile(self, halo_profile_model="nfw", massdef="mean", delta_mdef=200):


### PR DESCRIPTION
## Description

Makes the cosmology have the same `validate_input` as the theory object.

## Main changes
<!-- List the major changes in this PR-->
- Make  `validate_input`  an attibute of `Modeling`

## Checklist

Besides passing all CI checks and coverage is at 100%, make sure you also checked the following items
(check details in [CONTRIBUTING](https://github.com/LSSTDESC/CLMM/blob/main/CONTRIBUTING.md)).

### For developers

- [ ] **Notebooks:** notebooks related to this PR have been updated and all notebooks can run correctly.
- [ ] **Build the documentation:** All documentation builds correctly.

### For reviewers

- [ ] **Notebooks:** notebooks related to this PR have been updated and all notebooks can run correctly.
- [ ] **Build the documentation:** All documentation builds correctly.

### For developers (part 2)

After the PR has been approved by two reviewers:

- [ ] Update the code version in `clmm/__ini__.py`.
- [ ] Keep only relevant points in the squash and merge commit message.
